### PR TITLE
Use `mmd` and `mcopy`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ run:$(IMG_FILE) $(OVMF_VARS) $(OVMF_CODE)
 $(IMG_FILE):$(KERNEL_FILE) $(HEAD_FILE) $(EFI_FILE)
 	dd if=/dev/zero of=$@ bs=1k count=2880
 	mformat -i $@ -f 2880 ::
+	# Cannot replace these mmd and mcopy with `make copy_to_usb` because `mount` needs `sudo`
+	# regardless of the permission of the image file or the device. Using `mmd` and `mcopy` is
+	# the only way to edit image file without `sudo`.
 	mmd -i $@ ::/efi
 	mmd -i $@ ::/efi/boot
 	mcopy -i $@ $(KERNEL_FILE) ::

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,11 @@ run:$(IMG_FILE) $(OVMF_VARS) $(OVMF_CODE)
 $(IMG_FILE):$(KERNEL_FILE) $(HEAD_FILE) $(EFI_FILE)
 	dd if=/dev/zero of=$@ bs=1k count=2880
 	mformat -i $@ -f 2880 ::
-	USB_DEVICE_PATH=$(IMG_FILE) make copy_to_usb
+	mmd -i $@ ::/efi
+	mmd -i $@ ::/efi/boot
+	mcopy -i $@ $(KERNEL_FILE) ::
+	mcopy -i $@ $(HEAD_FILE) ::
+	mcopy -i $@ $(EFI_FILE) ::/efi/boot
 
 release:
 	make clean


### PR DESCRIPTION
Using `mount` needs `sudo`, regardless of the permission of the file or device.  Using `mmd` and `mcopy` is the only way to edit fat images without `sudo`.

Fixes: #14 