### PR TITLE
[Refactoring]Move lidt and lgdt and related functions

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -44,53 +44,6 @@ pub fn in8(port: u32) -> u8 {
     result
 }
 
-#[repr(C, packed)]
-struct GdtrIdtrData {
-    _limit: i16,
-    _address: u64,
-}
-
-impl GdtrIdtrData {
-    fn new(limit: i16, address: u64) -> Self {
-        Self {
-            _limit: limit,
-            _address: address,
-        }
-    }
-}
-
-pub fn lidt(limit: u16, address: u64) {
-    unsafe {
-        asm!("lidt [{:r}]",in(reg) &GdtrIdtrData::new(limit as i16, address),options(readonly, preserves_flags, nostack));
-    }
-}
-
-pub fn lgdt(limit: u16, address: u64) {
-    unsafe {
-        asm!("lgdt [{:r}]",in(reg) &GdtrIdtrData::new(limit as i16, address),options(readonly, preserves_flags, nostack));
-    }
-}
-
-/// Safety: `offset_of_cs` must be a valid offset to code segment. Otherwise unexpected
-/// behavior will occur.
-pub unsafe fn set_code_segment(offset_of_cs: u16) {
-    asm!("push {0:r}
-    lea rax, 1f
-    push rax
-    retfq
-    1:", in(reg) offset_of_cs,options(preserves_flags));
-}
-
-/// Safety: `offset_of_ds` must be a valid offset to data segment. Otherwise unexpected
-/// behavior will occur.
-pub unsafe fn set_data_segment(offset_of_ds: u16) {
-    asm!("mov es, ax
-    mov ss, ax
-    mov ds, ax
-    mov fs, ax
-    mov gs, ax",in("ax") offset_of_ds,options(nomem, preserves_flags, nostack));
-}
-
 // Don't put these asm! in one! It doesn't work!
 #[macro_export]
 macro_rules! interrupt_handler{

--- a/src/descriptor_table.rs
+++ b/src/descriptor_table.rs
@@ -1,7 +1,5 @@
 // See P.114
 
-use crate::asm;
-
 const VIRTUAL_ADDRESS_IDT: u64 = 0xFFFFFFFF80080000;
 const LIMIT_INTERRUPT_DESCRIPTOR_TABLE: u16 = 0x000007FF;
 const ACCESS_RIGHT_IDT: u32 = 0x008E;
@@ -29,6 +27,23 @@ impl GateDescriptor {
     }
 }
 
+fn lidt(limit: u16, address: u64) {
+    #[repr(C, packed)]
+    struct LidtEntry {
+        _limit: u16,
+        _address: u64,
+    };
+
+    let entry = LidtEntry {
+        _limit: limit,
+        _address: address,
+    };
+
+    unsafe {
+        asm!("lidt [{:r}]",in(reg) &entry,options(readonly, preserves_flags, nostack));
+    }
+}
+
 pub fn init() -> () {
     init_idt();
     set_interruption();
@@ -45,7 +60,7 @@ fn init_idt() -> () {
         }
     }
 
-    asm::lidt(LIMIT_INTERRUPT_DESCRIPTOR_TABLE, VIRTUAL_ADDRESS_IDT);
+    lidt(LIMIT_INTERRUPT_DESCRIPTOR_TABLE, VIRTUAL_ADDRESS_IDT);
 }
 
 fn set_interruption() {

--- a/src/gdt.rs
+++ b/src/gdt.rs
@@ -76,6 +76,7 @@ fn lgdt(limit: u16, address: u64) {
         _limit: limit,
         _address: address,
     };
+
     unsafe {
         asm!("lgdt [{:r}]",in(reg) &entry,options(readonly, preserves_flags, nostack));
     }


### PR DESCRIPTION
These functions are used in limited ways.

Fixes: #17 