### PR TITLE
Fix build error

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
       run: cargo install cargo-xbuild
 
     - name: Check rust-src
-      run: rustup component add rust-src && rustc --print sysroot && find / -name libstd 2>/dev/null && find $(rustc --print sysroot) -name libstd
+      run: rustup component add rust-src && rustc --print sysroot && find $(rustc --print sysroot) -name libstd
 
     - name: Build debug version
       run: rustup component add rust-src && make

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,9 +21,8 @@ jobs:
       uses: actions-rs/toolchain@v1.0.6
       with:
         toolchain: nightly
-        components: rust-src
         override: true
-    
+
     - name: Install rust-src
       run: rustup component add rust-src
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install rust nightly
-      run: rustup override set nightly-2020-07-22
+      run: rustup override set nightly-2020-07-25
 
     - name: Install dependencies
       run: sudo apt-get install nasm mtools

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,9 @@ jobs:
     - name: Check rust-src
       run: rustup component add rust-src && rustc --print sysroot && find $(rustc --print sysroot) -name libstd
 
+    - name: Get backtrace
+      run: RUST_BACKTRACE=1 cargo xbuild
+
     - name: Build debug version
       run: rustup component add rust-src && make
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
       run: cargo install cargo-xbuild
 
     - name: Check rust-src
-      run: rustup component add rust-src && rustc --print sysroot && ls -R $(rustc --print sysroot)
+      run: rustup component add rust-src && rustc --print sysroot && ls -R $(rustc --print sysroot)|grep libstd && rustup component list|grep rust-src
 
     - name: Build debug version
       run: rustup component add rust-src && make

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,10 +18,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install rust nightly
-      uses: actions-rs/toolchain@v1.0.6
-      with:
-        toolchain: nightly
-        override: true
+      run: rustup override set nightly
 
     - name: Install dependencies
       run: sudo apt-get install nasm mtools

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,9 @@ jobs:
         toolchain: nightly
         components: rust-src
         override: true
+    
+    - name: Install rust-src
+      run: rustup component add rust-src
 
     - name: Install dependencies
       run: sudo apt-get install nasm mtools

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
       run: cargo install cargo-xbuild
 
     - name: Check rust-src
-      run: rustup component add rust-src && rustc --print sysroot && find $(rustc --print sysroot) -name libstd
+      run: rustup component add rust-src && rustc --print sysroot && find / -name libstd && find $(rustc --print sysroot) -name libstd
 
     - name: Build debug version
       run: rustup component add rust-src && make

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
       run: cargo install cargo-xbuild
 
     - name: Check rust-src
-      run: rustup component add rust-src && rustc --print sysroot && find / -name libstd && find $(rustc --print sysroot) -name libstd
+      run: rustup component add rust-src && rustc --print sysroot && find / -name libstd 2&>/dev/null && find $(rustc --print sysroot) -name libstd
 
     - name: Build debug version
       run: rustup component add rust-src && make

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
       run: cargo install cargo-xbuild
 
     - name: Check rust-src
-      run: rustup component add rust-src && find $(rustc --print sysroot) -name libstd
+      run: rustup component add rust-src && rustc --print sysroot && find $(rustc --print sysroot) -name libstd
 
     - name: Build debug version
       run: rustup component add rust-src && make

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,17 +26,14 @@ jobs:
     - name: Install cargo-xbuild
       run: cargo install cargo-xbuild
 
-    - name: Check rust-src
-      run: rustup component add rust-src && rustc --print sysroot && ls -R $(rustc --print sysroot)|grep libstd && rustup component list|grep rust-src
-
-    - name: Check Cargo.toml
-      run: find $(rustc --print sysroot) -name Cargo.toml|grep libstd
+    - name: Install rust-src
+      run: rustup component add rust-src
 
     - name: Build debug version
-      run: rustup component add rust-src && make
+      run: make
 
     - name: Build release version
-      run: rustup component add rust-src && make release
+      run: make release
 
     - name: Create image file
       run: make build/ramen_os.img

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,9 +23,6 @@ jobs:
         toolchain: nightly
         override: true
 
-    - name: Install rust-src
-      run: rustup component add rust-src
-
     - name: Install dependencies
       run: sudo apt-get install nasm mtools
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install rust nightly
-      run: rustup override set nightly
+      run: rustup override set nightly-2020-07-22
 
     - name: Install dependencies
       run: sudo apt-get install nasm mtools

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,10 +33,10 @@ jobs:
       run: cargo install cargo-xbuild
 
     - name: Build debug version
-      run: make
+      run: rustup component add rust-src && make
 
     - name: Build release version
-      run: make release
+      run: rustup component add rust-src && make release
 
     - name: Create image file
       run: make build/ramen_os.img

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,9 +32,6 @@ jobs:
     - name: Check rust-src
       run: rustup component add rust-src && rustc --print sysroot && find $(rustc --print sysroot) -name libstd
 
-    - name: Get backtrace
-      run: RUST_BACKTRACE=1 cargo xbuild
-
     - name: Build debug version
       run: rustup component add rust-src && make
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
       run: cargo install cargo-xbuild
 
     - name: Check rust-src
-      run: rustup component add rust-src && rustc --print sysroot && find / -name libstd 2&>/dev/null && find $(rustc --print sysroot) -name libstd
+      run: rustup component add rust-src && rustc --print sysroot && find / -name libstd 2>/dev/null && find $(rustc --print sysroot) -name libstd
 
     - name: Build debug version
       run: rustup component add rust-src && make

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,9 @@ jobs:
     - name: Check rust-src
       run: rustup component add rust-src && rustc --print sysroot && ls -R $(rustc --print sysroot)|grep libstd && rustup component list|grep rust-src
 
+    - name: Check Cargo.toml
+      run: find $(rustc --print sysroot) -name Cargo.toml
+
     - name: Build debug version
       run: rustup component add rust-src && make
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,9 @@ jobs:
     - name: Install cargo-xbuild
       run: cargo install cargo-xbuild
 
+    - name: Check rust-src
+      run: rustup component add rust-src && find $(rustc --print sysroot) -name libstd
+
     - name: Build debug version
       run: rustup component add rust-src && make
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
       run: cargo install cargo-xbuild
 
     - name: Check rust-src
-      run: rustup component add rust-src && rustc --print sysroot && find $(rustc --print sysroot) -name libstd
+      run: rustup component add rust-src && rustc --print sysroot && ls -R $(rustc --print sysroot)
 
     - name: Build debug version
       run: rustup component add rust-src && make

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
       run: rustup component add rust-src && rustc --print sysroot && ls -R $(rustc --print sysroot)|grep libstd && rustup component list|grep rust-src
 
     - name: Check Cargo.toml
-      run: find $(rustc --print sysroot) -name Cargo.toml
+      run: find $(rustc --print sysroot) -name Cargo.toml|grep libstd
 
     - name: Build debug version
       run: rustup component add rust-src && make


### PR DESCRIPTION
`rust-src` should be installed during "Install rust nightly". However, this doesn't work. Add an explicit installing code to solve this.