### PR TITLE
Define addrs and size structs in common items

### DIFF
--- a/bootx64/src/exit.rs
+++ b/bootx64/src/exit.rs
@@ -1,4 +1,5 @@
 use crate::common_items;
+use crate::common_items::addr::{Addr, Virt};
 use crate::mem::paging;
 use core::ptr;
 use uefi::table::boot;
@@ -31,10 +32,10 @@ fn jump_to_kernel(boot_info: common_items::BootInfo) -> ! {
 
     unsafe {
         asm!("mov rsp, rax
-        jmp rdi",in("rax") common_items::INIT_RSP,in("rdi") fetch_entry_address(),options(nomem, preserves_flags, nostack,noreturn));
+        jmp rdi",in("rax") common_items::INIT_RSP,in("rdi") fetch_entry_address().as_usize(),options(nomem, preserves_flags, nostack,noreturn));
     }
 }
 
-fn fetch_entry_address() -> u64 {
-    unsafe { ptr::read(0xffff_ffff_8000_0000 as *const u64) }
+fn fetch_entry_address() -> Addr<Virt> {
+    Addr::new(unsafe { ptr::read(0xffff_ffff_8000_0000 as *const u64) } as _)
 }

--- a/bootx64/src/fs/kernel_bytes.rs
+++ b/bootx64/src/fs/kernel_bytes.rs
@@ -1,9 +1,11 @@
+use crate::common_items::addr::{Addr, Virt};
+use crate::common_items::size::{Byte, Size};
 use core::ptr;
 use uefi::proto::media::file;
 
 struct KernelHeader {
-    _entry_addr: usize,
-    memory_bytes: usize,
+    _entry_addr: Addr<Virt>,
+    memory_bytes: Size<Byte>,
 }
 
 impl KernelHeader {
@@ -17,7 +19,7 @@ impl KernelHeader {
     }
 }
 
-pub fn get(root_dir: &mut file::Directory) -> usize {
+pub fn get(root_dir: &mut file::Directory) -> Size<Byte> {
     let mut handler = super::get_kernel_handler(root_dir);
 
     let mut header = [0u8; 16];

--- a/bootx64/src/main.rs
+++ b/bootx64/src/main.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(lang_items, start, asm)]
+#![feature(start, asm)]
 #![no_main]
 
 extern crate rlibc;

--- a/common_items/src/addr.rs
+++ b/common_items/src/addr.rs
@@ -1,0 +1,14 @@
+use core::marker::PhantomData;
+
+trait AddrType {}
+
+pub struct Phys {}
+impl AddrType for Phys {}
+
+pub struct Virt {}
+impl AddrType for Virt {}
+
+pub struct Addr<T: AddrType> {
+    addr: usize,
+    _marker: PhantomData<fn() -> T>,
+}

--- a/common_items/src/addr.rs
+++ b/common_items/src/addr.rs
@@ -17,7 +17,7 @@ pub struct Addr<T: AddrType> {
 }
 
 impl<T: AddrType> Addr<T> {
-    pub fn new(addr: usize) -> Self {
+    pub const fn new(addr: usize) -> Self {
         Self {
             addr,
             _marker: PhantomData,

--- a/common_items/src/addr.rs
+++ b/common_items/src/addr.rs
@@ -1,14 +1,49 @@
 use core::marker::PhantomData;
 
-trait AddrType {}
+pub trait AddrType {}
 
+#[derive(Copy, Clone)]
 pub struct Phys {}
 impl AddrType for Phys {}
 
+#[derive(Copy, Clone)]
 pub struct Virt {}
 impl AddrType for Virt {}
 
+#[derive(Copy, Clone)]
 pub struct Addr<T: AddrType> {
     addr: usize,
     _marker: PhantomData<fn() -> T>,
+}
+
+impl<T: AddrType> Addr<T> {
+    pub fn new(addr: usize) -> Self {
+        Self {
+            addr,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn offset(&self, offset: isize) -> Self {
+        Self {
+            addr: (self.addr as isize + offset) as _,
+            ..*self
+        }
+    }
+}
+
+impl Addr<Phys> {
+    pub fn as_usize(&self) -> usize {
+        self.addr
+    }
+
+    pub fn as_mut_ptr(&self) -> *mut usize {
+        self.addr as *mut _
+    }
+}
+
+impl Addr<Virt> {
+    pub fn as_usize(&self) -> usize {
+        ((self.addr as isize) << 16 >> 16) as _
+    }
 }

--- a/common_items/src/lib.rs
+++ b/common_items/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
+#![feature(const_fn)]
 
 pub mod addr;
+pub mod size;
 
 extern crate uefi;
 

--- a/common_items/src/lib.rs
+++ b/common_items/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+pub mod addr;
+
 extern crate uefi;
 
 use core::mem::size_of;

--- a/common_items/src/size.rs
+++ b/common_items/src/size.rs
@@ -1,0 +1,44 @@
+use core::marker::PhantomData;
+
+pub trait Unit {}
+
+#[derive(Copy, Clone)]
+pub struct Byte;
+impl Unit for Byte {}
+
+#[derive(Copy, Clone)]
+pub struct NumOfPages;
+impl Unit for NumOfPages {}
+
+#[derive(Copy, Clone)]
+pub struct Size<T: Unit> {
+    num: usize,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<T: Unit> Size<T> {
+    pub fn new(num: usize) -> Self {
+        Self {
+            num,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn as_usize(&self) -> usize {
+        self.num
+    }
+}
+
+const BYTES_OF_PAGE: usize = 0x1000;
+
+impl Size<Byte> {
+    pub fn as_num_of_pages(&self) -> Size<NumOfPages> {
+        Size::new((self.num + BYTES_OF_PAGE - 1) / BYTES_OF_PAGE)
+    }
+}
+
+impl Size<NumOfPages> {
+    pub fn as_byes(&self) -> Size<Byte> {
+        Size::new(self.num * BYTES_OF_PAGE)
+    }
+}


### PR DESCRIPTION
Difficult to replace all `usize`s to `Addr` and `Size` at once. Not all these types are replaced.