### PR TITLE
Define `PhysAddr` and `VirtAddr`

### DIFF
--- a/bootx64/src/exit.rs
+++ b/bootx64/src/exit.rs
@@ -1,5 +1,5 @@
 use crate::common_items;
-use crate::common_items::addr::{Addr, Virt};
+use crate::common_items::addr::VirtAddr;
 use crate::mem::paging;
 use core::ptr;
 use uefi::table::boot;
@@ -36,6 +36,6 @@ fn jump_to_kernel(boot_info: common_items::BootInfo) -> ! {
     }
 }
 
-fn fetch_entry_address() -> Addr<Virt> {
-    Addr::new(unsafe { ptr::read(0xffff_ffff_8000_0000 as *const u64) } as _)
+fn fetch_entry_address() -> VirtAddr {
+    VirtAddr::new(unsafe { ptr::read(0xffff_ffff_8000_0000 as *const u64) } as _)
 }

--- a/bootx64/src/fs.rs
+++ b/bootx64/src/fs.rs
@@ -1,4 +1,4 @@
-use crate::common_items::addr::{Addr, Phys};
+use crate::common_items::addr::PhysAddr;
 use crate::common_items::size::{Byte, Size};
 use uefi::prelude::{Boot, SystemTable};
 use uefi::proto::media::file;
@@ -13,11 +13,11 @@ mod kernel_bytes;
 
 struct KernelFileInfo {
     name: &'static str,
-    start_address: Addr<Phys>,
+    start_address: PhysAddr,
 }
 
 impl KernelFileInfo {
-    const fn new(name: &'static str, start_address: Addr<Phys>) -> Self {
+    const fn new(name: &'static str, start_address: PhysAddr) -> Self {
         Self {
             name,
             start_address,
@@ -28,7 +28,7 @@ impl KernelFileInfo {
         self.name
     }
 
-    fn address(&self) -> Addr<Phys> {
+    fn address(&self) -> PhysAddr {
         self.start_address
     }
 }
@@ -36,7 +36,7 @@ impl KernelFileInfo {
 // Using the size of binary as the memory consumption is useless because the size of .bss section
 // is not included in the binary size. Using ELF file may improve effeciency as it might contain
 // the size of memory comsuption.
-const KERNEL_FILE: KernelFileInfo = KernelFileInfo::new("kernel.bin", Addr::new(0x200000));
+const KERNEL_FILE: KernelFileInfo = KernelFileInfo::new("kernel.bin", PhysAddr::new(0x200000));
 
 pub fn place_kernel(system_table: &SystemTable<Boot>) -> () {
     let mut root_dir = open_root_dir(system_table);

--- a/bootx64/src/fs/kernel_bytes.rs
+++ b/bootx64/src/fs/kernel_bytes.rs
@@ -1,10 +1,10 @@
-use crate::common_items::addr::{Addr, Virt};
+use crate::common_items::addr::VirtAddr;
 use crate::common_items::size::{Byte, Size};
 use core::ptr;
 use uefi::proto::media::file;
 
 struct KernelHeader {
-    _entry_addr: Addr<Virt>,
+    _entry_addr: VirtAddr,
     memory_bytes: Size<Byte>,
 }
 

--- a/common_items/src/addr.rs
+++ b/common_items/src/addr.rs
@@ -32,7 +32,10 @@ impl<T: AddrType> Addr<T> {
     }
 }
 
-impl Addr<Phys> {
+pub type PhysAddr = Addr<Phys>;
+pub type VirtAddr = Addr<Virt>;
+
+impl PhysAddr {
     pub fn as_usize(&self) -> usize {
         self.addr
     }
@@ -42,7 +45,7 @@ impl Addr<Phys> {
     }
 }
 
-impl Addr<Virt> {
+impl VirtAddr {
     pub fn as_usize(&self) -> usize {
         ((self.addr as isize) << 16 >> 16) as _
     }


### PR DESCRIPTION
You don't have to type `<` and `>` and include `Addr`.

Fixes: #76 