### PR TITLE
[Change]The physical addr of kernel is not fixed

### DIFF
--- a/bootx64/src/exit.rs
+++ b/bootx64/src/exit.rs
@@ -8,12 +8,19 @@ use x86_64::{PhysAddr, VirtAddr};
 pub fn bootx64<'a>(
     mem_map: &'a mut [boot::MemoryDescriptor],
     boot_info: common_items::BootInfo,
+    kernel_addr: PhysAddr,
     bytes_kernel: Size<Byte>,
     stack_addr: PhysAddr,
 ) -> ! {
     disable_interruption();
 
-    paging::init(mem_map, &boot_info.vram(), bytes_kernel, stack_addr);
+    paging::init(
+        mem_map,
+        &boot_info.vram(),
+        kernel_addr,
+        bytes_kernel,
+        stack_addr,
+    );
     jump_to_kernel(boot_info);
 }
 

--- a/bootx64/src/main.rs
+++ b/bootx64/src/main.rs
@@ -39,7 +39,7 @@ pub fn efi_main(image: Handle, system_table: SystemTable<Boot>) -> ! {
 
     let vram_info = gop::init(&system_table);
 
-    let bytes_kernel = fs::place_kernel(&system_table);
+    let (kernel_addr, bytes_kernel) = fs::place_kernel(&system_table);
 
     let stack_addr = stack::allocate(system_table.boot_services());
     let mem_map = terminate_boot_services(image, system_table);
@@ -49,6 +49,7 @@ pub fn efi_main(image: Handle, system_table: SystemTable<Boot>) -> ! {
     exit::bootx64(
         mem_map,
         common_items::BootInfo::new(vram_info, mem_map_info),
+        kernel_addr,
         bytes_kernel,
         stack_addr,
     );

--- a/bootx64/src/mem/paging.rs
+++ b/bootx64/src/mem/paging.rs
@@ -24,13 +24,14 @@ impl PageMapInfo {
 pub fn init(
     mem_map: &mut [boot::MemoryDescriptor],
     vram: &common_items::VramInfo,
+    addr_kernel: PhysAddr,
     bytes_kernel: Size<Byte>,
     stack_addr: PhysAddr,
 ) -> () {
     remove_table_protection();
 
     let map_info = [
-        PageMapInfo::new(KERNEL_ADDR, PhysAddr::new(0x0020_0000), bytes_kernel),
+        PageMapInfo::new(KERNEL_ADDR, addr_kernel, bytes_kernel),
         PageMapInfo::new(VRAM_ADDR, vram.phys_ptr(), vram.bytes()),
         PageMapInfo::new(
             STACK_BASE - NUM_OF_PAGES_STACK.as_bytes().as_usize(),

--- a/os.ld
+++ b/os.ld
@@ -20,17 +20,19 @@ SECTIONS
 
     .data : {
         *(.data)
+    } > kernel
+
+    .rodata : {
         *(.rodata*)
-        *(.bss)
     } > kernel
 
     .bss : {
-        .start = .;
         *(.bss)
-        .end = .;
     } > kernel
 
-    /DISCARD/ : { *(.eh_frame) }
+    .eh_frame : {
+        *(.eh_frame)
+    } > kernel
 
     tail_addr = .;
 }


### PR DESCRIPTION
Avoid using `AddressType::Address`. The specified address may not be usable.