### PR TITLE
Define kernel module

### DIFF
--- a/bootx64/src/fs.rs
+++ b/bootx64/src/fs.rs
@@ -1,0 +1,2 @@
+pub mod kernel;
+mod root_dir;

--- a/bootx64/src/fs/kernel/size.rs
+++ b/bootx64/src/fs/kernel/size.rs
@@ -20,7 +20,7 @@ impl KernelHeader {
 }
 
 pub fn get(root_dir: &mut file::Directory) -> Size<Byte> {
-    let mut handler = super::get_kernel_handler(root_dir);
+    let mut handler = super::get_handler(root_dir);
 
     let mut header = [0u8; 16];
 

--- a/bootx64/src/fs/root_dir.rs
+++ b/bootx64/src/fs/root_dir.rs
@@ -1,0 +1,17 @@
+use uefi::prelude::{Boot, SystemTable};
+use uefi::proto::media::file;
+use uefi::proto::media::fs;
+use uefi::ResultExt;
+
+pub fn open(system_table: &SystemTable<Boot>) -> file::Directory {
+    let simple_file_system = system_table
+        .boot_services()
+        .locate_protocol::<fs::SimpleFileSystem>()
+        .expect_success("Failed to prepare simple file system.");
+
+    let simple_file_system = unsafe { &mut *simple_file_system.get() };
+
+    simple_file_system
+        .open_volume()
+        .expect_success("Failed to open the root directory.")
+}

--- a/bootx64/src/main.rs
+++ b/bootx64/src/main.rs
@@ -19,13 +19,14 @@ extern crate common_items;
 extern crate x86_64;
 
 mod exit;
+mod fs;
 mod gop;
 mod init;
-mod kernel;
 mod mem;
 
 use core::ptr;
 use core::slice;
+use fs::kernel;
 use mem::stack;
 use uefi::prelude::{Boot, Handle, SystemTable};
 use uefi::table::boot;
@@ -39,7 +40,7 @@ pub fn efi_main(image: Handle, system_table: SystemTable<Boot>) -> ! {
 
     let vram_info = gop::init(&system_table);
 
-    let (kernel_addr, bytes_kernel) = kernel::place_kernel(&system_table);
+    let (kernel_addr, bytes_kernel) = kernel::deploy(&system_table);
 
     let stack_addr = stack::allocate(system_table.boot_services());
     let mem_map = terminate_boot_services(image, system_table);


### PR DESCRIPTION
Fixes: #92 

Although the `fs` module still exists.