### PR TITLE
Fix the crash on release build

### DIFF
--- a/bootx64/src/main.rs
+++ b/bootx64/src/main.rs
@@ -53,10 +53,12 @@ pub fn efi_main(image: Handle, system_table: SystemTable<Boot>) -> ! {
     paging::init(system_table.boot_services(), &reserved_regions);
     let mem_map = terminate_boot_services(image, system_table);
 
-    exit::bootx64(
+    exit::bootx64(kernelboot::Info::new(
         entry_addr,
-        kernelboot::Info::new(vram_info, mem_map, reserved_regions),
-    );
+        vram_info,
+        mem_map,
+        reserved_regions,
+    ));
 }
 
 fn init_libs(system_table: &SystemTable<Boot>) -> () {

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,4 +9,4 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 uefi = "0.5.0"
-x86_64 = "0.11.2"
+x86_64 = "0.11.4"

--- a/common/src/boot.rs
+++ b/common/src/boot.rs
@@ -5,21 +5,33 @@ use crate::mem;
 use crate::mem::reserved;
 use crate::vram;
 use core::ptr;
+use x86_64::VirtAddr;
 
 #[repr(C)]
 pub struct Info {
+    entry_addr: VirtAddr,
     vram_info: vram::Info,
     mem_map: mem::Map,
     reserved: reserved::Map,
 }
 
 impl Info {
-    pub fn new(vram_info: vram::Info, mem_map: mem::Map, reserved: reserved::Map) -> Self {
+    pub fn new(
+        entry_addr: VirtAddr,
+        vram_info: vram::Info,
+        mem_map: mem::Map,
+        reserved: reserved::Map,
+    ) -> Self {
         Self {
+            entry_addr,
             vram_info,
             mem_map,
             reserved,
         }
+    }
+
+    pub fn entry_addr(&self) -> VirtAddr {
+        self.entry_addr
     }
 
     pub fn vram(&self) -> vram::Info {

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -25,4 +25,4 @@ crate-type = ["staticlib"]
 spin = "0.5.2"
 common = { path = "../common" }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
-x86_64 = "0.11.2"
+x86_64 = "0.11.4"

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -26,7 +26,7 @@ use x86_64::instructions::interrupts;
 
 #[no_mangle]
 #[start]
-pub fn os_main() {
+pub fn os_main() -> ! {
     let boot_info = boot::Info::get();
     let vram = graphics::Vram::new_from_boot_info(&boot_info);
 
@@ -72,7 +72,7 @@ fn main_loop(
     mouse_device: &mut interrupt::mouse::Device,
     mouse_cursor: &mut graphics::screen::MouseCursor,
     vram: &graphics::Vram,
-) -> () {
+) -> ! {
     loop {
         interrupts::disable();
         if interrupt::KEY_QUEUE.lock().size() != 0 {


### PR DESCRIPTION
The address of the entry point of the kernel wasn't saved. This commit makes `boot::Info` include the address so that it will also be saved.

Fixes: #139 