### PR TITLE
Split `allocator` module into `phys` and `heap`

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -21,7 +21,6 @@ extern crate alloc;
 extern crate log;
 extern crate x86_64;
 
-mod allocator;
 mod device;
 mod gdt;
 mod idt;
@@ -34,13 +33,13 @@ mod panic;
 mod graphics;
 
 use {
-    allocator::FrameManager,
     common::kernelboot,
     device::{keyboard, mouse},
     graphics::{
         screen::{self, desktop::Desktop, layer},
         Vram,
     },
+    mem::allocator::{heap, phys::FrameManager},
     multitask::{executor::Executor, task::Task},
 };
 
@@ -61,7 +60,7 @@ fn initialization(boot_info: &kernelboot::Info) {
 
     FrameManager::init(boot_info.mem_map());
 
-    allocator::init_heap();
+    heap::init();
 
     layer::init();
 

--- a/kernel/src/mem/allocator/heap.rs
+++ b/kernel/src/mem/allocator/heap.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use {
+    super::{super::paging::pml4::PML4, phys::FRAME_MANAGER},
+    common::constant::{BYTES_KERNEL_HEAP, KERNEL_HEAP_ADDR},
+    core::{alloc::Layout, convert::TryFrom},
+    linked_list_allocator::LockedHeap,
+    x86_64::structures::paging::{
+        FrameAllocator, Mapper, Page, PageSize, PageTableFlags, Size4KiB,
+    },
+};
+
+#[global_allocator]
+pub static ALLOCATOR: LockedHeap = LockedHeap::empty();
+
+// Using UEFI's `allocate_pages` doesn't work for allocating larger memory. It returns out of
+// resrouces.
+pub fn init() {
+    for i in 0..BYTES_KERNEL_HEAP.as_num_of_pages::<Size4KiB>().as_usize() {
+        let frame = FRAME_MANAGER
+            .lock()
+            .allocate_frame()
+            .expect("OOM during initializing heap memory.");
+        let page =
+            Page::<Size4KiB>::containing_address(KERNEL_HEAP_ADDR + Size4KiB::SIZE * i as u64);
+        unsafe {
+            PML4.lock()
+                .map_to(
+                    page,
+                    frame,
+                    PageTableFlags::PRESENT,
+                    &mut *FRAME_MANAGER.lock(),
+                )
+                .unwrap()
+                .flush();
+        };
+    }
+
+    unsafe {
+        ALLOCATOR.lock().init(
+            usize::try_from(KERNEL_HEAP_ADDR.as_u64()).unwrap(),
+            BYTES_KERNEL_HEAP.as_usize(),
+        )
+    }
+}
+
+#[alloc_error_handler]
+fn alloc_error(layout: Layout) -> ! {
+    panic!("Allocation failed! {:?}", layout);
+}

--- a/kernel/src/mem/allocator/heap.rs
+++ b/kernel/src/mem/allocator/heap.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+// WORKAROUND: https://stackoverflow.com/questions/63933070/clippy-says-too-many-arguments-to-static-declaration
+#![allow(clippy::too_many_arguments)]
+
 use {
     super::{super::paging::pml4::PML4, phys::FRAME_MANAGER},
     common::constant::{BYTES_KERNEL_HEAP, KERNEL_HEAP_ADDR},

--- a/kernel/src/mem/allocator/mod.rs
+++ b/kernel/src/mem/allocator/mod.rs
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pub mod allocator;
-pub mod paging;
+pub mod heap;
+pub mod phys;

--- a/kernel/src/mem/allocator/phys.rs
+++ b/kernel/src/mem/allocator/phys.rs
@@ -1,25 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#![allow(clippy::too_many_arguments)]
 use {
-    crate::mem::paging::pml4::PML4,
-    common::constant::{BYTES_KERNEL_HEAP, CHANGE_FREE_PAGE_ADDR, KERNEL_HEAP_ADDR},
+    common::constant::CHANGE_FREE_PAGE_ADDR,
     conquer_once::spin::Lazy,
-    core::{alloc::Layout, convert::TryFrom, ptr},
-    linked_list_allocator::LockedHeap,
+    core::ptr,
     spinning_top::Spinlock,
-    uefi::table::{boot, boot::MemoryType},
+    uefi::table::boot::{self, MemoryType},
     x86_64::{
         instructions::tlb,
-        structures::paging::{
-            FrameAllocator, Mapper, Page, PageSize, PageTableFlags, PhysFrame, Size4KiB,
-        },
+        structures::paging::{FrameAllocator, PageSize, PhysFrame, Size4KiB},
         PhysAddr,
     },
 };
-
-#[global_allocator]
-pub static ALLOCATOR: LockedHeap = LockedHeap::empty();
 
 pub static FRAME_MANAGER: Lazy<Spinlock<FrameManager>> = Lazy::new(|| {
     Spinlock::new(FrameManager {
@@ -27,42 +19,6 @@ pub static FRAME_MANAGER: Lazy<Spinlock<FrameManager>> = Lazy::new(|| {
         tail: None,
     })
 });
-
-// Using UEFI's `allocate_pages` doesn't work for allocating larger memory. It returns out of
-// resrouces.
-pub fn init_heap() {
-    for i in 0..BYTES_KERNEL_HEAP.as_num_of_pages::<Size4KiB>().as_usize() {
-        let frame = FRAME_MANAGER
-            .lock()
-            .allocate_frame()
-            .expect("OOM during initializing heap memory.");
-        let page =
-            Page::<Size4KiB>::containing_address(KERNEL_HEAP_ADDR + Size4KiB::SIZE * i as u64);
-        unsafe {
-            PML4.lock()
-                .map_to(
-                    page,
-                    frame,
-                    PageTableFlags::PRESENT,
-                    &mut *FRAME_MANAGER.lock(),
-                )
-                .unwrap()
-                .flush();
-        };
-    }
-
-    unsafe {
-        ALLOCATOR.lock().init(
-            usize::try_from(KERNEL_HEAP_ADDR.as_u64()).unwrap(),
-            BYTES_KERNEL_HEAP.as_usize(),
-        )
-    }
-}
-
-#[alloc_error_handler]
-fn alloc_error(layout: Layout) -> ! {
-    panic!("Allocation failed! {:?}", layout);
-}
 
 pub struct FrameManager {
     head: Option<PhysAddr>,


### PR DESCRIPTION
Fixes: #187 