### PR TITLE
Initialize heap manager first

### DIFF
--- a/bootx64/src/mem/paging.rs
+++ b/bootx64/src/mem/paging.rs
@@ -47,7 +47,7 @@ pub fn init(boot_info: &mut kernelboot::Info) {
 
     let reserved = *boot_info.reserved();
 
-    let mut allocator = AllocatorWithEfiMemoryMap::new(boot_info.mem_map());
+    let mut allocator = AllocatorWithEfiMemoryMap::new(boot_info.mem_map_mut());
 
     for region in reserved.iter() {
         map_virt_to_phys(region, &mut allocator);

--- a/common/src/kernelboot.rs
+++ b/common/src/kernelboot.rs
@@ -52,7 +52,7 @@ impl Info {
     }
 
     #[must_use]
-    pub fn mem_map(&mut self) -> &mut [boot::MemoryDescriptor] {
+    pub fn mem_map_mut(&mut self) -> &mut [boot::MemoryDescriptor] {
         self.mem_map.as_mut_slice()
     }
 

--- a/common/src/kernelboot.rs
+++ b/common/src/kernelboot.rs
@@ -53,7 +53,7 @@ impl Info {
 
     #[must_use]
     pub fn mem_map(&mut self) -> &mut [boot::MemoryDescriptor] {
-        self.mem_map.as_slice()
+        self.mem_map.as_mut_slice()
     }
 
     #[must_use]

--- a/common/src/mem/mod.rs
+++ b/common/src/mem/mod.rs
@@ -21,7 +21,7 @@ impl Map {
     }
 
     #[must_use]
-    pub fn as_slice(&mut self) -> &mut [boot::MemoryDescriptor] {
+    pub fn as_mut_slice(&mut self) -> &mut [boot::MemoryDescriptor] {
         unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.num_descriptors) }
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -60,9 +60,9 @@ fn initialization(boot_info: &mut kernelboot::Info) {
 
     interrupts::enable();
 
-    FrameManager::init(boot_info.mem_map_mut());
+    heap::init(boot_info.mem_map_mut());
 
-    heap::init();
+    FrameManager::init(boot_info.mem_map_mut());
 
     layer::init();
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -60,7 +60,7 @@ fn initialization(boot_info: &mut kernelboot::Info) {
 
     interrupts::enable();
 
-    FrameManager::init(boot_info.mem_map());
+    FrameManager::init(boot_info.mem_map_mut());
 
     heap::init();
 


### PR DESCRIPTION
- Rename to `as_mut_slice`
- Rename to `mem_map_mut`
- Initialize heap area before initializing page manager

To use `alloc` crate for initializing page manager. Fixes: #225

bors r+
