### PR TITLE
Implement `PageBox` type

### DIFF
--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -7,14 +7,9 @@ mod transfer_ring;
 
 use {
     super::config::{self, bar},
-    crate::mem::{
-        accessor::slice,
-        allocator::{page_box::PageBox, phys::FRAME_MANAGER},
-        paging::pml4::PML4,
-    },
+    crate::mem::{allocator::page_box::PageBox, paging::pml4::PML4},
     core::convert::TryFrom,
     futures_util::{task::AtomicWaker, StreamExt},
-    os_units::Bytes,
     register::{
         hc_capability_registers::HCCapabilityRegisters,
         hc_operational_registers::HCOperationalRegisters,
@@ -22,10 +17,7 @@ use {
         usb_legacy_support_capability::UsbLegacySupportCapability,
     },
     transfer_ring::{Command, Event, RingQueue},
-    x86_64::{
-        structures::paging::{FrameAllocator, MapperAllSizes},
-        PhysAddr,
-    },
+    x86_64::{structures::paging::MapperAllSizes, PhysAddr},
 };
 
 static WAKER: AtomicWaker = AtomicWaker::new();

--- a/kernel/src/mem/allocator/mod.rs
+++ b/kernel/src/mem/allocator/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 pub mod heap;
+pub mod page_box;
 pub mod phys;
 pub mod virt;

--- a/kernel/src/mem/allocator/page_box.rs
+++ b/kernel/src/mem/allocator/page_box.rs
@@ -1,0 +1,1 @@
+// SPDX-License-Identifier: GPL-3.0-or-later

--- a/kernel/src/mem/allocator/page_box.rs
+++ b/kernel/src/mem/allocator/page_box.rs
@@ -24,7 +24,7 @@ pub struct PageBox<T: ?Sized> {
     _marker: PhantomData<T>,
 }
 impl<T> PageBox<[T]> {
-    fn new_slice(num_of_elements: usize) -> Self {
+    pub fn new_slice(num_of_elements: usize) -> Self {
         let bytes = Bytes::new(mem::size_of::<T>() * num_of_elements);
         let virt = Self::allocate_pages(bytes.as_num_of_pages());
 

--- a/kernel/src/mem/allocator/page_box.rs
+++ b/kernel/src/mem/allocator/page_box.rs
@@ -1,8 +1,96 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use {core::marker::PhantomData, x86_64::VirtAddr};
+use {
+    super::{super::paging::pml4::PML4, phys::FRAME_MANAGER, virt},
+    core::{
+        convert::TryFrom,
+        marker::PhantomData,
+        mem,
+        ops::{Deref, DerefMut},
+        slice,
+    },
+    os_units::{Bytes, NumOfPages},
+    x86_64::{
+        structures::paging::{
+            FrameDeallocator, Mapper, Page, PageSize, PageTableFlags, PhysFrame, Size4KiB,
+        },
+        VirtAddr,
+    },
+};
 
-pub struct PageBox<T> {
+pub struct PageBox<T: ?Sized> {
     virt: VirtAddr,
+    bytes: Bytes,
     _marker: PhantomData<T>,
+}
+impl<T> PageBox<[T]> {
+    fn new_slice(num_of_elements: usize) -> Self {
+        let bytes = Bytes::new(mem::size_of::<T>() * num_of_elements);
+        let virt = Self::allocate_pages(bytes.as_num_of_pages());
+
+        Self {
+            virt,
+            bytes,
+            _marker: PhantomData::<[T]>,
+        }
+    }
+
+    fn num_of_elements(&self) -> usize {
+        self.bytes.as_usize() / mem::size_of::<T>()
+    }
+}
+impl<T> Deref for PageBox<[T]> {
+    type Target = [T];
+    fn deref(&self) -> &Self::Target {
+        unsafe { slice::from_raw_parts(self.virt.as_ptr(), self.num_of_elements()) }
+    }
+}
+impl<T> DerefMut for PageBox<[T]> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { slice::from_raw_parts_mut(self.virt.as_mut_ptr(), self.num_of_elements()) }
+    }
+}
+impl<T: ?Sized> PageBox<T> {
+    fn allocate_pages(num_of_pages: NumOfPages<Size4KiB>) -> VirtAddr {
+        let virt_addr =
+            virt::search_free_addr(num_of_pages).expect("OOM during creating `PageBox`");
+
+        let phys_addr = FRAME_MANAGER
+            .lock()
+            .alloc(num_of_pages)
+            .expect("OOM during creating `PageBox");
+
+        for i in 0..u64::try_from(num_of_pages.as_usize()).unwrap() {
+            let page =
+                Page::<Size4KiB>::from_start_address(virt_addr + Size4KiB::SIZE * i).unwrap();
+            let frame = PhysFrame::from_start_address(phys_addr + Size4KiB::SIZE * i).unwrap();
+
+            unsafe {
+                PML4.lock()
+                    .map_to(
+                        page,
+                        frame,
+                        PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+                        &mut *FRAME_MANAGER.lock(),
+                    )
+                    .unwrap()
+                    .flush()
+            }
+        }
+
+        virt_addr
+    }
+}
+impl<T: ?Sized> Drop for PageBox<T> {
+    fn drop(&mut self) {
+        let num_of_pages = self.bytes.as_num_of_pages::<Size4KiB>();
+
+        for i in 0..u64::try_from(num_of_pages.as_usize()).unwrap() {
+            let page = Page::from_start_address(self.virt + Size4KiB::SIZE * i).unwrap();
+
+            let (frame, flush) = PML4.lock().unmap(page).unwrap();
+            flush.flush();
+            unsafe { FRAME_MANAGER.lock().deallocate_frame(frame) }
+        }
+    }
 }

--- a/kernel/src/mem/allocator/page_box.rs
+++ b/kernel/src/mem/allocator/page_box.rs
@@ -12,9 +12,10 @@ use {
     os_units::{Bytes, NumOfPages},
     x86_64::{
         structures::paging::{
-            FrameDeallocator, Mapper, Page, PageSize, PageTableFlags, PhysFrame, Size4KiB,
+            FrameDeallocator, Mapper, MapperAllSizes, Page, PageSize, PageTableFlags, PhysFrame,
+            Size4KiB,
         },
-        VirtAddr,
+        PhysAddr, VirtAddr,
     },
 };
 
@@ -33,6 +34,10 @@ impl<T> PageBox<[T]> {
             bytes,
             _marker: PhantomData::<[T]>,
         }
+    }
+
+    pub fn phys_addr(&self) -> PhysAddr {
+        PML4.lock().translate_addr(self.virt).unwrap()
     }
 
     fn num_of_elements(&self) -> usize {

--- a/kernel/src/mem/allocator/page_box.rs
+++ b/kernel/src/mem/allocator/page_box.rs
@@ -1,1 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+use {core::marker::PhantomData, x86_64::VirtAddr};
+
+pub struct PageBox<T> {
+    virt: VirtAddr,
+    _marker: PhantomData<T>,
+}


### PR DESCRIPTION
- Define `page_box` module
- Define `PageBox` type
- Define `PageBox` for slice
- Make `new_slice` public
- Define `PageBox::phys_addr`
- Use `PageBox` for DCBAA
- Remove unnecessary imports

`slice::Accessor` is still remaining because if will not drop physical pages while `PageBox` will.

bors r+
