### PR TITLE
Implement enqueue for command ring

### DIFF
--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -5,14 +5,12 @@ use {super::Raw, x86_64::PhysAddr};
 pub struct Ring {
     raw: Raw,
     enqueue_ptr: usize,
-    len: usize,
 }
 impl Ring {
     pub fn new(len: usize) -> Self {
         Self {
             raw: Raw::new(len),
             enqueue_ptr: 0,
-            len,
         }
     }
 

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -1,20 +1,31 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use {super::Raw, x86_64::PhysAddr};
+use {
+    super::Raw,
+    super::{trb::Trb, CycleBit},
+    x86_64::PhysAddr,
+};
 
 pub struct Ring {
     raw: Raw,
     enqueue_ptr: usize,
+    cycle_bit: CycleBit,
 }
 impl Ring {
     pub fn new(len: usize) -> Self {
         Self {
             raw: Raw::new(len),
             enqueue_ptr: 0,
+            cycle_bit: CycleBit::new(true),
         }
     }
 
     pub fn phys_addr(&self) -> PhysAddr {
         self.raw.phys_addr()
+    }
+
+    fn enqueueable(&self) -> bool {
+        let raw = self.raw[self.enqueue_ptr];
+        raw.cycle_bit() != self.cycle_bit
     }
 }

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -24,8 +24,28 @@ impl Ring {
         self.raw.phys_addr()
     }
 
+    fn enqueue(&mut self, trb: Trb) {
+        if !self.enqueueable() {
+            return;
+        }
+
+        self.raw[self.enqueue_ptr] = trb.into();
+
+        self.enqueue_ptr += 1;
+        if self.enqueue_ptr < self.len() {
+            return;
+        }
+
+        self.enqueue_ptr %= self.len();
+        self.cycle_bit.toggle();
+    }
+
     fn enqueueable(&self) -> bool {
         let raw = self.raw[self.enqueue_ptr];
         raw.cycle_bit() != self.cycle_bit
+    }
+
+    fn len(&self) -> usize {
+        self.raw.len()
     }
 }

--- a/kernel/src/device/pci/xhci/ring/mod.rs
+++ b/kernel/src/device/pci/xhci/ring/mod.rs
@@ -37,7 +37,7 @@ impl IndexMut<usize> for Raw {
 }
 
 #[derive(PartialOrd, Ord, PartialEq, Eq)]
-struct CycleBit(bool);
+pub struct CycleBit(bool);
 impl CycleBit {
     fn new(val: bool) -> Self {
         Self(val)

--- a/kernel/src/device/pci/xhci/ring/trb.rs
+++ b/kernel/src/device/pci/xhci/ring/trb.rs
@@ -76,6 +76,13 @@ impl Raw {
         self.into()
     }
 }
+impl From<Trb> for Raw {
+    fn from(trb: Trb) -> Self {
+        match trb {
+            Trb::Noop(noop) => Self(noop.0),
+        }
+    }
+}
 impl From<u128> for Raw {
     fn from(raw: u128) -> Self {
         Self(raw)

--- a/kernel/src/device/pci/xhci/ring/trb.rs
+++ b/kernel/src/device/pci/xhci/ring/trb.rs
@@ -71,6 +71,11 @@ impl From<Raw> for CycleBit {
         Self((raw.0 >> 96) & 1 != 0)
     }
 }
+impl Raw {
+    pub fn cycle_bit(self) -> CycleBit {
+        self.into()
+    }
+}
 impl From<u128> for Raw {
     fn from(raw: u128) -> Self {
         Self(raw)

--- a/kernel/src/device/pci/xhci/ring/trb.rs
+++ b/kernel/src/device/pci/xhci/ring/trb.rs
@@ -71,3 +71,8 @@ impl From<Raw> for CycleBit {
         Self((raw.0 >> 96) & 1 != 0)
     }
 }
+impl From<u128> for Raw {
+    fn from(raw: u128) -> Self {
+        Self(raw)
+    }
+}


### PR DESCRIPTION
- Make it possible to generate `Raw` from `u128`
- Remove `len`
- Define `enqueueable`
- Define `Raw::from`
- Define `enqueue`

bors r+
