### PR TITLE
Sent No op TRB

### DIFF
--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -52,6 +52,8 @@ impl<'a> Xhci {
         self.set_event_ring_dequeue_pointer();
         self.init_event_ring_segment_table();
         self.run();
+
+        self.issue_noop();
     }
 
     fn get_ownership_from_bios(&mut self) {
@@ -119,6 +121,11 @@ impl<'a> Xhci {
 
     fn run(&mut self) {
         self.hc_operational_registers.run();
+    }
+
+    fn issue_noop(&mut self) {
+        self.command_ring.send_noop();
+        self.doorbell_array.notify_to_hc();
     }
 
     fn new(config_space: &config::Space) -> Result<Self, Error> {

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -41,7 +41,7 @@ pub struct Xhci {
 }
 
 impl<'a> Xhci {
-    pub fn init(&mut self) {
+    fn init(&mut self) {
         self.get_ownership_from_bios();
         self.reset_hc();
         self.wait_until_hc_is_ready();

--- a/kernel/src/device/pci/xhci/register/doorbell.rs
+++ b/kernel/src/device/pci/xhci/register/doorbell.rs
@@ -1,0 +1,1 @@
+// SPDX-License-Identifier: GPL-3.0-or-later

--- a/kernel/src/device/pci/xhci/register/doorbell.rs
+++ b/kernel/src/device/pci/xhci/register/doorbell.rs
@@ -16,6 +16,10 @@ impl Array {
             NUM_OF_REGISTERS,
         ))
     }
+
+    fn notify_to_hc(&mut self) {
+        self.0[0].write_for_hc();
+    }
 }
 
 #[repr(transparent)]

--- a/kernel/src/device/pci/xhci/register/doorbell.rs
+++ b/kernel/src/device/pci/xhci/register/doorbell.rs
@@ -7,9 +7,9 @@ use {
 
 const NUM_OF_REGISTERS: usize = 256;
 
-struct Array(Accessor<[Register]>);
+pub struct Array(Accessor<[Register]>);
 impl Array {
-    fn new(mmio_base: PhysAddr, db_off: DoorbellOffset) -> Self {
+    pub fn new(mmio_base: PhysAddr, db_off: &DoorbellOffset) -> Self {
         Self(Accessor::new_slice(
             mmio_base,
             Bytes::new(db_off.get().try_into().unwrap()),

--- a/kernel/src/device/pci/xhci/register/doorbell.rs
+++ b/kernel/src/device/pci/xhci/register/doorbell.rs
@@ -17,7 +17,7 @@ impl Array {
         ))
     }
 
-    fn notify_to_hc(&mut self) {
+    pub fn notify_to_hc(&mut self) {
         self.0[0].write_for_hc();
     }
 }

--- a/kernel/src/device/pci/xhci/register/doorbell.rs
+++ b/kernel/src/device/pci/xhci/register/doorbell.rs
@@ -1,1 +1,27 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+use {
+    super::hc_capability_registers::DoorbellOffset, crate::mem::accessor::Accessor,
+    core::convert::TryInto, os_units::Bytes, x86_64::PhysAddr,
+};
+
+const NUM_OF_REGISTERS: usize = 256;
+
+struct Array(Accessor<[Register]>);
+impl Array {
+    fn new(mmio_base: PhysAddr, db_off: DoorbellOffset) -> Self {
+        Self(Accessor::new_slice(
+            mmio_base,
+            Bytes::new(db_off.get().try_into().unwrap()),
+            NUM_OF_REGISTERS,
+        ))
+    }
+}
+
+#[repr(transparent)]
+struct Register(u32);
+impl Register {
+    fn write_for_hc(&mut self) {
+        self.0 = 0;
+    }
+}

--- a/kernel/src/device/pci/xhci/register/hc_capability_registers.rs
+++ b/kernel/src/device/pci/xhci/register/hc_capability_registers.rs
@@ -75,6 +75,14 @@ bitfield! {
 }
 
 #[repr(transparent)]
+struct DoorbellOffset(u32);
+impl DoorbellOffset {
+    fn get(&self) -> u32 {
+        self.0
+    }
+}
+
+#[repr(transparent)]
 struct RuntimeRegisterSpaceOffset(u32);
 impl RuntimeRegisterSpaceOffset {
     fn get(&self) -> u32 {

--- a/kernel/src/device/pci/xhci/register/hc_capability_registers.rs
+++ b/kernel/src/device/pci/xhci/register/hc_capability_registers.rs
@@ -6,6 +6,7 @@ pub struct HCCapabilityRegisters {
     cap_length: Accessor<CapabilityRegistersLength>,
     hcs_params_1: Accessor<StructuralParameters1>,
     hc_cp_params_1: Accessor<HCCapabilityParameters1>,
+    db_off: Accessor<DoorbellOffset>,
     rts_off: Accessor<RuntimeRegisterSpaceOffset>,
 }
 
@@ -14,6 +15,7 @@ impl HCCapabilityRegisters {
         let cap_length = Accessor::new(mmio_base, Bytes::new(0));
         let hcs_params_1 = Accessor::new(mmio_base, Bytes::new(0x04));
         let hc_cp_params_1 = Accessor::new(mmio_base, Bytes::new(0x10));
+        let db_off = Accessor::new(mmio_base, Bytes::new(0x14));
         let rts_off = Accessor::new(mmio_base, Bytes::new(0x18));
 
         let hci_version = Accessor::<HCInterfaceVersionNumber>::new(mmio_base, Bytes::new(0x2));
@@ -23,6 +25,7 @@ impl HCCapabilityRegisters {
             cap_length,
             hcs_params_1,
             hc_cp_params_1,
+            db_off,
             rts_off,
         }
     }

--- a/kernel/src/device/pci/xhci/register/hc_capability_registers.rs
+++ b/kernel/src/device/pci/xhci/register/hc_capability_registers.rs
@@ -46,6 +46,10 @@ impl HCCapabilityRegisters {
         info!("RTSOFF: {}", self.rts_off.get());
         self.rts_off.get()
     }
+
+    pub fn db_off(&self) -> &DoorbellOffset {
+        &*self.db_off
+    }
 }
 
 #[repr(transparent)]
@@ -78,9 +82,9 @@ bitfield! {
 }
 
 #[repr(transparent)]
-struct DoorbellOffset(u32);
+pub struct DoorbellOffset(u32);
 impl DoorbellOffset {
-    fn get(&self) -> u32 {
+    pub fn get(&self) -> u32 {
         self.0
     }
 }

--- a/kernel/src/device/pci/xhci/register/mod.rs
+++ b/kernel/src/device/pci/xhci/register/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+pub mod doorbell;
 pub mod hc_capability_registers;
 pub mod hc_operational_registers;
 pub mod runtime_base_registers;

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -24,6 +24,11 @@ impl Ring {
         self.raw.phys_addr()
     }
 
+    pub fn send_noop(&mut self) {
+        let noop = Trb::new_noop(self.cycle_bit);
+        self.enqueue(noop);
+    }
+
     fn enqueue(&mut self, trb: Trb) {
         if !self.enqueueable() {
             return;

--- a/kernel/src/device/pci/xhci/ring/event/mod.rs
+++ b/kernel/src/device/pci/xhci/ring/event/mod.rs
@@ -46,11 +46,7 @@ impl<'a> Ring {
 
     fn empty(&self) -> bool {
         let raw_trb = self.raw[self.dequeue_ptr];
-        if Trb::try_from(raw_trb).is_ok() {
-            CycleBit::from(raw_trb) != self.current_cycle_bit
-        } else {
-            true
-        }
+        CycleBit::from(raw_trb) != self.current_cycle_bit
     }
 
     fn increment(&mut self) {

--- a/kernel/src/device/pci/xhci/ring/mod.rs
+++ b/kernel/src/device/pci/xhci/ring/mod.rs
@@ -36,7 +36,7 @@ impl IndexMut<usize> for Raw {
     }
 }
 
-#[derive(PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CycleBit(bool);
 impl CycleBit {
     fn new(val: bool) -> Self {

--- a/kernel/src/device/pci/xhci/ring/trb.rs
+++ b/kernel/src/device/pci/xhci/ring/trb.rs
@@ -83,8 +83,3 @@ impl From<Trb> for Raw {
         }
     }
 }
-impl From<u128> for Raw {
-    fn from(raw: u128) -> Self {
-        Self(raw)
-    }
-}

--- a/kernel/src/device/pci/xhci/ring/trb.rs
+++ b/kernel/src/device/pci/xhci/ring/trb.rs
@@ -23,7 +23,7 @@ pub enum Trb {
     Noop(Noop),
 }
 impl Trb {
-    fn new_noop(cycle_bit: CycleBit) -> Self {
+    pub fn new_noop(cycle_bit: CycleBit) -> Self {
         Self::Noop(Noop::new(cycle_bit))
     }
 }

--- a/kernel/src/device/pci/xhci/ring/trb.rs
+++ b/kernel/src/device/pci/xhci/ring/trb.rs
@@ -22,6 +22,11 @@ impl TryFrom<Raw> for Ty {
 pub enum Trb {
     Noop(Noop),
 }
+impl Trb {
+    fn new_noop(cycle_bit: CycleBit) -> Self {
+        Self::Noop(Noop::new(cycle_bit))
+    }
+}
 impl TryFrom<Raw> for Trb {
     type Error = Error;
 

--- a/kernel/src/device/pci/xhci/ring/trb.rs
+++ b/kernel/src/device/pci/xhci/ring/trb.rs
@@ -51,7 +51,7 @@ bitfield! {
     pub struct Noop(u128);
 
     _, set_cycle_bit: 96;
-    _, set_trb_type: 96+15, 96+10;
+    trb_type, set_trb_type: (96+15), (96+10);
 }
 impl Noop {
     fn new(cycle_bit: CycleBit) -> Self {


### PR DESCRIPTION
- Remove an unnecessary `pub`
- Remove an unused trait implementation
- Define `Trb::new_noop`
- Add `pub`
- Define `DoorbellOffset`
- Add `db_off` as a member
- Add `doorbell` module
- Define doorbell array
- Define `notify_to_hc`
- Add `door_bell` as a member
- Issue an event ring

To confirm that the event and command ring work properly.

bors r+
