### PR TITLE
Remove `Ty` type

### DIFF
--- a/kernel/src/device/pci/xhci/ring/raw.rs
+++ b/kernel/src/device/pci/xhci/ring/raw.rs
@@ -3,7 +3,10 @@
 use {
     super::{trb, CycleBit},
     crate::mem::allocator::page_box::PageBox,
-    core::ops::{Index, IndexMut},
+    core::{
+        convert::TryInto,
+        ops::{Index, IndexMut},
+    },
     x86_64::PhysAddr,
 };
 
@@ -39,6 +42,10 @@ pub struct Trb(pub u128);
 impl Trb {
     pub fn cycle_bit(self) -> CycleBit {
         self.into()
+    }
+
+    pub fn ty(self) -> u8 {
+        ((self.0 >> 106) & 0x3f).try_into().unwrap()
     }
 }
 impl From<trb::Trb> for Trb {


### PR DESCRIPTION
To prevent from forgetting to change parts of codes.

bors r+
