### PR TITLE
Remove `reserved` from boot information

### DIFF
--- a/bootx64/src/exit.rs
+++ b/bootx64/src/exit.rs
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use {
-    crate::mem::paging,
-    common::{constant::INIT_RSP, kernelboot},
-};
+use common::{constant::INIT_RSP, kernelboot};
 
 macro_rules! change_rsp{
     ($val:expr)=>{
@@ -13,10 +10,8 @@ macro_rules! change_rsp{
     }
 }
 
-pub fn bootx64(mut boot_info: kernelboot::Info) -> ! {
+pub fn bootx64(boot_info: kernelboot::Info) -> ! {
     disable_interruption();
-
-    paging::init(&mut boot_info);
 
     jump_to_kernel(boot_info);
 }

--- a/bootx64/src/main.rs
+++ b/bootx64/src/main.rs
@@ -51,12 +51,10 @@ pub fn efi_main(image: Handle, system_table: SystemTable<Boot>) -> ! {
     );
     let mem_map = terminate_boot_services(image, system_table);
 
-    exit::bootx64(kernelboot::Info::new(
-        entry_addr,
-        vram_info,
-        mem_map,
-        reserved_regions,
-    ));
+    let mut boot_info = kernelboot::Info::new(entry_addr, vram_info, mem_map);
+
+    paging::init(&mut boot_info, &reserved_regions);
+    exit::bootx64(boot_info);
 }
 
 fn init_libs(system_table: &SystemTable<Boot>) {

--- a/bootx64/src/mem/paging.rs
+++ b/bootx64/src/mem/paging.rs
@@ -5,7 +5,7 @@ use common::kernelboot;
 use common::mem::reserved;
 use core::convert::TryFrom;
 use uefi::table::boot;
-use uefi::table::boot::{AllocateType, MemoryType};
+use uefi::table::boot::MemoryType;
 use x86_64::addr::PhysAddr;
 use x86_64::registers::control::Cr3;
 use x86_64::registers::control::{Cr0, Cr0Flags};
@@ -40,12 +40,10 @@ unsafe impl<'a> FrameAllocator<Size4KiB> for AllocatorWithEfiMemoryMap<'a> {
     }
 }
 
-pub fn init(boot_info: &mut kernelboot::Info) {
+pub fn init(boot_info: &mut kernelboot::Info, reserved: &reserved::Map) {
     remove_table_protection();
 
     enable_recursive_mapping();
-
-    let reserved = *boot_info.reserved();
 
     let mut allocator = AllocatorWithEfiMemoryMap::new(boot_info.mem_map_mut());
 

--- a/common/src/kernelboot.rs
+++ b/common/src/kernelboot.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::{constant::INIT_RSP, mem, mem::reserved, vram};
+use crate::{constant::INIT_RSP, mem, vram};
 use core::ptr;
 use uefi::table::boot;
 use x86_64::VirtAddr;
@@ -10,23 +10,16 @@ pub struct Info {
     entry_addr: VirtAddr,
     vram_info: vram::Info,
     mem_map: mem::Map,
-    reserved: reserved::Map,
 }
 
 impl Info {
     #[allow(clippy::too_many_arguments)]
     #[must_use]
-    pub fn new(
-        entry_addr: VirtAddr,
-        vram_info: vram::Info,
-        mem_map: mem::Map,
-        reserved: reserved::Map,
-    ) -> Self {
+    pub fn new(entry_addr: VirtAddr, vram_info: vram::Info, mem_map: mem::Map) -> Self {
         Self {
             entry_addr,
             vram_info,
             mem_map,
-            reserved,
         }
     }
 
@@ -54,10 +47,5 @@ impl Info {
     #[must_use]
     pub fn mem_map_mut(&mut self) -> &mut [boot::MemoryDescriptor] {
         self.mem_map.as_mut_slice()
-    }
-
-    #[must_use]
-    pub fn reserved(&self) -> &reserved::Map {
-        &self.reserved
     }
 }


### PR DESCRIPTION
This is not used by the kernel.

bors r+
