### PR TITLE
Increment event ring dequeue pointer

### DIFF
--- a/kernel/src/device/pci/xhci/ring/event/mod.rs
+++ b/kernel/src/device/pci/xhci/ring/event/mod.rs
@@ -105,6 +105,10 @@ impl<'a> Ring<'a> {
                 self.current_cycle_bit.toggle();
             }
         }
+
+        self.registers
+            .lock()
+            .set_event_ring_dequeue_pointer(self.phys_addr_to_next_trb())
     }
 
     fn phys_addr_to_next_trb(&self) -> PhysAddr {

--- a/kernel/src/device/pci/xhci/ring/event/mod.rs
+++ b/kernel/src/device/pci/xhci/ring/event/mod.rs
@@ -107,6 +107,11 @@ impl<'a> Ring<'a> {
         }
     }
 
+    fn phys_addr_to_next_trb(&self) -> PhysAddr {
+        self.arrays[self.dequeue_ptr_segment].phys_addr()
+            + Trb::SIZE.as_usize() * self.dequeue_ptr_trb
+    }
+
     fn num_of_segment_table(&self) -> usize {
         self.arrays.len()
     }

--- a/kernel/src/device/pci/xhci/ring/trb.rs
+++ b/kernel/src/device/pci/xhci/ring/trb.rs
@@ -4,6 +4,7 @@ use {
     super::{raw, CycleBit},
     bitfield::bitfield,
     core::convert::TryFrom,
+    os_units::Bytes,
 };
 
 #[derive(Debug)]
@@ -12,6 +13,7 @@ pub enum Trb {
     CommandComplete(CommandComplete),
 }
 impl Trb {
+    pub const SIZE: Bytes = Bytes::new(16);
     pub fn new_noop(cycle_bit: CycleBit) -> Self {
         Self::Noop(Noop::new(cycle_bit))
     }


### PR DESCRIPTION
- Define `phys_addr_to_next_trb`
- Increment event ring dequeue pointer after dequeue

bors r+
