### PR TITLE
Split `command_ring` member

### DIFF
--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -19,7 +19,10 @@ pub async fn task() {
     let registers = Spinlock::new(iter_devices().next().unwrap());
     let mut xhci = Xhci::new(&registers);
     let mut event_ring = event::Ring::new(&registers);
+    let mut command_ring = command::Ring::new(&registers);
     xhci.init();
+
+    command_ring.send_noop();
 
     while let Some(trb) = event_ring.next().await {
         info!("TRB: {:?}", trb);
@@ -28,7 +31,6 @@ pub async fn task() {
 
 pub struct Xhci<'a> {
     dcbaa: DeviceContextBaseAddressArray,
-    command_ring: command::Ring<'a>,
     registers: &'a Spinlock<Registers>,
 }
 
@@ -39,10 +41,7 @@ impl<'a> Xhci<'a> {
         self.wait_until_ready();
         self.set_num_of_enabled_slots();
         self.set_dcbaap();
-        self.set_command_ring_pointer();
         self.run();
-
-        self.issue_noop();
     }
 
     fn get_ownership_from_bios(&mut self) {
@@ -65,19 +64,8 @@ impl<'a> Xhci<'a> {
         self.registers.lock().set_dcbaap(self.dcbaa.phys_addr())
     }
 
-    fn set_command_ring_pointer(&mut self) {
-        self.registers
-            .lock()
-            .set_command_ring_pointer(self.command_ring.phys_addr())
-    }
-
     fn run(&mut self) {
         self.registers.lock().run_hc()
-    }
-
-    fn issue_noop(&mut self) {
-        self.command_ring.send_noop();
-        self.registers.lock().notify_to_hc();
     }
 
     fn new(registers: &'a Spinlock<Registers>) -> Self {
@@ -86,11 +74,7 @@ impl<'a> Xhci<'a> {
 
     fn generate(registers: &'a Spinlock<Registers>) -> Self {
         let dcbaa = DeviceContextBaseAddressArray::new(registers.lock().num_of_device_slots());
-        Self {
-            registers,
-            dcbaa,
-            command_ring: command::Ring::new(registers),
-        }
+        Self { registers, dcbaa }
     }
 }
 

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -28,7 +28,7 @@ pub async fn task() {
 
 pub struct Xhci<'a> {
     dcbaa: DeviceContextBaseAddressArray,
-    command_ring: command::Ring,
+    command_ring: command::Ring<'a>,
     registers: &'a Spinlock<Registers>,
 }
 
@@ -89,7 +89,7 @@ impl<'a> Xhci<'a> {
         Self {
             registers,
             dcbaa,
-            command_ring: command::Ring::new(),
+            command_ring: command::Ring::new(registers),
         }
     }
 }

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -2,24 +2,27 @@
 
 use {
     super::raw,
-    super::{trb::Trb, CycleBit},
+    super::{super::Registers, trb::Trb, CycleBit},
+    spinning_top::Spinlock,
     x86_64::PhysAddr,
 };
 
 // 4KB / 16 = 256
 const SIZE_OF_RING: usize = 256;
 
-pub struct Ring {
+pub struct Ring<'a> {
     raw: raw::Ring,
     enqueue_ptr: usize,
     cycle_bit: CycleBit,
+    registers: &'a Spinlock<Registers>,
 }
-impl Ring {
-    pub fn new() -> Self {
+impl<'a> Ring<'a> {
+    pub fn new(registers: &'a Spinlock<Registers>) -> Self {
         Self {
             raw: raw::Ring::new(SIZE_OF_RING),
             enqueue_ptr: 0,
             cycle_bit: CycleBit::new(true),
+            registers,
         }
     }
 


### PR DESCRIPTION
- Add `registers` as a member of the command ring
- Split `command_ring` from `xhci`

bors r+
