### PR TITLE
Fix codes of xHC resetting

### DIFF
--- a/kernel/src/device/pci/xhci/dcbaa.rs
+++ b/kernel/src/device/pci/xhci/dcbaa.rs
@@ -13,11 +13,10 @@ impl<'a> DeviceContextBaseAddressArray<'a> {
     pub fn new(registers: &'a Spinlock<Registers>) -> Self {
         let arr = PageBox::new_slice(Self::num_of_slots(registers));
         let dcbaa = Self { arr, registers };
-        dcbaa.init();
         dcbaa
     }
 
-    fn init(&self) {
+    pub fn init(&self) {
         self.register_address_to_xhci_register();
     }
 

--- a/kernel/src/device/pci/xhci/dcbaa.rs
+++ b/kernel/src/device/pci/xhci/dcbaa.rs
@@ -12,8 +12,7 @@ pub struct DeviceContextBaseAddressArray<'a> {
 impl<'a> DeviceContextBaseAddressArray<'a> {
     pub fn new(registers: &'a Spinlock<Registers>) -> Self {
         let arr = PageBox::new_slice(Self::num_of_slots(registers));
-        let dcbaa = Self { arr, registers };
-        dcbaa
+        Self { arr, registers }
     }
 
     pub fn init(&self) {

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -20,8 +20,14 @@ pub async fn task() {
     let mut xhc = Xhc::new(&registers);
     let mut event_ring = event::Ring::new(&registers);
     let mut command_ring = command::Ring::new(&registers);
-    let _dcbaa = DeviceContextBaseAddressArray::new(&registers);
+    let dcbaa = DeviceContextBaseAddressArray::new(&registers);
+
     xhc.init();
+    event_ring.init();
+    command_ring.init();
+    dcbaa.init();
+
+    xhc.run();
 
     command_ring.send_noop();
 
@@ -40,7 +46,6 @@ impl<'a> Xhc<'a> {
         self.reset_if_halted();
         self.wait_until_ready();
         self.set_num_of_enabled_slots();
-        self.run();
     }
 
     fn get_ownership_from_bios(&mut self) {

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -24,7 +24,6 @@ impl<'a> Ring<'a> {
             cycle_bit: CycleBit::new(true),
             registers,
         };
-        command_ring.init();
         command_ring
     }
 
@@ -42,7 +41,7 @@ impl<'a> Ring<'a> {
         self.registers.lock().doorbell_array[0] = 0;
     }
 
-    fn init(&mut self) {
+    pub fn init(&mut self) {
         self.register_address_to_xhci_register();
     }
 

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -18,13 +18,12 @@ pub struct Ring<'a> {
 }
 impl<'a> Ring<'a> {
     pub fn new(registers: &'a Spinlock<Registers>) -> Self {
-        let mut command_ring = Self {
+        Self {
             raw: raw::Ring::new(SIZE_OF_RING),
             enqueue_ptr: 0,
             cycle_bit: CycleBit::new(true),
             registers,
-        };
-        command_ring
+        }
     }
 
     pub fn phys_addr(&self) -> PhysAddr {

--- a/kernel/src/device/pci/xhci/ring/event/mod.rs
+++ b/kernel/src/device/pci/xhci/ring/event/mod.rs
@@ -35,15 +35,14 @@ impl<'a> Ring<'a> {
             .hcs_params_2
             .powered_erst_max();
 
-        let ring = Self {
+        Self {
             arrays: Self::new_arrays(max_num_of_erst),
             segment_table: SegmentTable::new(max_num_of_erst.into()),
             current_cycle_bit: CycleBit::new(true),
             dequeue_ptr_trb: 0,
             dequeue_ptr_segment: 0,
             registers,
-        };
-        ring
+        }
     }
 
     pub fn init(&mut self) {

--- a/kernel/src/device/pci/xhci/ring/event/mod.rs
+++ b/kernel/src/device/pci/xhci/ring/event/mod.rs
@@ -35,7 +35,7 @@ impl<'a> Ring<'a> {
             .hcs_params_2
             .powered_erst_max();
 
-        let mut ring = Self {
+        let ring = Self {
             arrays: Self::new_arrays(max_num_of_erst),
             segment_table: SegmentTable::new(max_num_of_erst.into()),
             current_cycle_bit: CycleBit::new(true),
@@ -43,9 +43,12 @@ impl<'a> Ring<'a> {
             dequeue_ptr_segment: 0,
             registers,
         };
-        ring.init_dequeue_ptr();
-        ring.init_segment_table();
         ring
+    }
+
+    pub fn init(&mut self) {
+        self.init_dequeue_ptr();
+        self.init_segment_table();
     }
 
     fn init_dequeue_ptr(&mut self) {


### PR DESCRIPTION
- Run xHC after all components are initialized
- Remove unnecessary `let` bindings

bors r+
