### PR TITLE
Set command ring cycle state

### DIFF
--- a/kernel/src/device/pci/xhci/register/hc_operational.rs
+++ b/kernel/src/device/pci/xhci/register/hc_operational.rs
@@ -54,6 +54,7 @@ bitfield! {
     #[repr(transparent)]
     pub struct CommandRingControlRegister(u64);
 
+    pub _, set_ring_cycle_state: 0;
     ptr,set_pointer:63,6;
 }
 impl CommandRingControlRegister {

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -42,7 +42,7 @@ impl<'a> Ring<'a> {
 
     pub fn init(&mut self) {
         self.register_address_to_xhci_register();
-        self.init_command_ring_cycle_state();
+        self.set_initial_command_ring_cycle_state();
     }
 
     fn register_address_to_xhci_register(&mut self) {
@@ -53,7 +53,7 @@ impl<'a> Ring<'a> {
             .set_ptr(self.phys_addr());
     }
 
-    fn init_command_ring_cycle_state(&mut self) {
+    fn set_initial_command_ring_cycle_state(&mut self) {
         let crcr = &mut self.registers.lock().hc_operational.crcr;
         crcr.set_ring_cycle_state(true);
     }

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -42,6 +42,7 @@ impl<'a> Ring<'a> {
 
     pub fn init(&mut self) {
         self.register_address_to_xhci_register();
+        self.init_command_ring_cycle_state();
     }
 
     fn register_address_to_xhci_register(&mut self) {
@@ -50,6 +51,11 @@ impl<'a> Ring<'a> {
             .hc_operational
             .crcr
             .set_ptr(self.phys_addr());
+    }
+
+    fn init_command_ring_cycle_state(&mut self) {
+        let crcr = &mut self.registers.lock().hc_operational.crcr;
+        crcr.set_ring_cycle_state(true);
     }
 
     fn enqueue(&mut self, trb: Trb) {

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -46,11 +46,8 @@ impl<'a> Ring<'a> {
     }
 
     fn register_address_to_xhci_register(&mut self) {
-        self.registers
-            .lock()
-            .hc_operational
-            .crcr
-            .set_ptr(self.phys_addr());
+        let crcr = &mut self.registers.lock().hc_operational.crcr;
+        crcr.set_ptr(self.phys_addr());
     }
 
     fn set_initial_command_ring_cycle_state(&mut self) {


### PR DESCRIPTION
- Define `init_command_ring_cycle_state`
- Rename to `set_initial_command_ring_cycle_state`
- Reduce the number of lines

bors r+
