### PR TITLE
refactor: wrap `registers` with `Rc` and `RefCell`

### DIFF
--- a/kernel/src/device/mouse.rs
+++ b/kernel/src/device/mouse.rs
@@ -67,7 +67,6 @@ struct Device {
     speed: Vec2<i32>,
     buttons: MouseButtons,
 }
-
 impl Device {
     const fn new() -> Self {
         Self {
@@ -203,7 +202,6 @@ impl Buf {
 }
 
 struct PacketStream;
-
 impl PacketStream {
     fn init_queue() {
         MOUSE_PACKET_QUEUE
@@ -211,7 +209,6 @@ impl PacketStream {
             .expect("MOUSE_PACKET_QUEUE is already initialized.")
     }
 }
-
 impl Stream for PacketStream {
     type Item = u8;
 
@@ -252,7 +249,6 @@ struct MouseButtons {
     center: bool,
     right: bool,
 }
-
 impl MouseButtons {
     const fn new() -> Self {
         Self {

--- a/kernel/src/device/pci/xhci/dcbaa.rs
+++ b/kernel/src/device/pci/xhci/dcbaa.rs
@@ -11,7 +11,7 @@ pub struct DeviceContextBaseAddressArray {
 }
 impl<'a> DeviceContextBaseAddressArray {
     pub fn new(registers: Rc<RefCell<Registers>>) -> Self {
-        let arr = PageBox::new_slice(Self::num_of_slots(registers.clone()));
+        let arr = PageBox::new_slice(Self::num_of_slots(&registers));
         Self { arr, registers }
     }
 
@@ -19,7 +19,7 @@ impl<'a> DeviceContextBaseAddressArray {
         self.register_address_to_xhci_register();
     }
 
-    fn num_of_slots(registers: Rc<RefCell<Registers>>) -> usize {
+    fn num_of_slots(registers: &Rc<RefCell<Registers>>) -> usize {
         let params1 = &registers.borrow().hc_capability.hcs_params_1;
         (params1.read().max_slots() + 1).into()
     }

--- a/kernel/src/device/pci/xhci/dcbaa.rs
+++ b/kernel/src/device/pci/xhci/dcbaa.rs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use {
-    super::Registers, crate::mem::allocator::page_box::PageBox, spinning_top::Spinlock,
+    super::Registers, crate::mem::allocator::page_box::PageBox, alloc::rc::Rc, core::cell::RefCell,
     x86_64::PhysAddr,
 };
 
-pub struct DeviceContextBaseAddressArray<'a> {
+pub struct DeviceContextBaseAddressArray {
     arr: PageBox<[usize]>,
-    registers: &'a Spinlock<Registers>,
+    registers: Rc<RefCell<Registers>>,
 }
-impl<'a> DeviceContextBaseAddressArray<'a> {
-    pub fn new(registers: &'a Spinlock<Registers>) -> Self {
-        let arr = PageBox::new_slice(Self::num_of_slots(registers));
+impl<'a> DeviceContextBaseAddressArray {
+    pub fn new(registers: Rc<RefCell<Registers>>) -> Self {
+        let arr = PageBox::new_slice(Self::num_of_slots(registers.clone()));
         Self { arr, registers }
     }
 
@@ -19,13 +19,13 @@ impl<'a> DeviceContextBaseAddressArray<'a> {
         self.register_address_to_xhci_register();
     }
 
-    fn num_of_slots(registers: &'a Spinlock<Registers>) -> usize {
-        let params1 = &registers.lock().hc_capability.hcs_params_1;
+    fn num_of_slots(registers: Rc<RefCell<Registers>>) -> usize {
+        let params1 = &registers.borrow().hc_capability.hcs_params_1;
         (params1.read().max_slots() + 1).into()
     }
 
     fn register_address_to_xhci_register(&self) {
-        let dcbaap = &mut self.registers.lock().hc_operational.dcbaap;
+        let dcbaap = &mut self.registers.borrow_mut().hc_operational.dcbaap;
         dcbaap.update(|dcbaap| dcbaap.set(self.phys_addr()));
     }
 

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -42,7 +42,7 @@ fn init(
     let mut event_ring = event::Ring::new(registers.clone());
     let mut command_ring = command::Ring::new(registers.clone());
     let dcbaa = DeviceContextBaseAddressArray::new(registers.clone());
-    let ports = port::Collection::new(registers);
+    let ports = port::Collection::new(&registers);
 
     xhc.init();
 

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -19,7 +19,7 @@ static WAKER: AtomicWaker = AtomicWaker::new();
 
 pub async fn task() {
     let registers = Rc::new(RefCell::new(iter_devices().next().unwrap()));
-    let (_xhc, mut event_ring, mut command_ring, _dcbaa, mut ports) = init(registers);
+    let (_xhc, mut event_ring, mut command_ring, _dcbaa, mut ports) = init(&registers);
     command_ring.send_noop();
 
     ports.enable_all_connected_ports();
@@ -30,7 +30,7 @@ pub async fn task() {
 }
 
 fn init(
-    registers: Rc<RefCell<Registers>>,
+    registers: &Rc<RefCell<Registers>>,
 ) -> (
     Xhc,
     event::Ring,

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -2,19 +2,18 @@
 
 use {
     super::register::{hc_operational::PortRegisters, Registers},
-    alloc::vec::Vec,
-    core::slice,
-    spinning_top::Spinlock,
+    alloc::{rc::Rc, vec::Vec},
+    core::{cell::RefCell, slice},
 };
 
-pub struct Collection<'a> {
-    collection: Vec<Port<'a>>,
+pub struct Collection {
+    collection: Vec<Port>,
 }
-impl<'a> Collection<'a> {
-    pub fn new(registers: &'a Spinlock<Registers>) -> Self {
+impl<'a> Collection {
+    pub fn new(registers: Rc<RefCell<Registers>>) -> Self {
         let mut collection = Vec::new();
-        for i in 0..Self::num_of_ports(registers) {
-            collection.push(Port::new(registers, i));
+        for i in 0..Self::num_of_ports(registers.clone()) {
+            collection.push(Port::new(registers.clone(), i));
         }
 
         Self { collection }
@@ -26,32 +25,32 @@ impl<'a> Collection<'a> {
         }
     }
 
-    fn num_of_ports(registers: &Spinlock<Registers>) -> usize {
-        let params1 = &registers.lock().hc_capability.hcs_params_1;
+    fn num_of_ports(registers: Rc<RefCell<Registers>>) -> usize {
+        let params1 = &registers.borrow().hc_capability.hcs_params_1;
         params1.read().max_ports().into()
     }
 }
-impl<'a> IntoIterator for &'a mut Collection<'a> {
-    type Item = &'a mut Port<'a>;
-    type IntoIter = slice::IterMut<'a, Port<'a>>;
+impl<'a> IntoIterator for &'a mut Collection {
+    type Item = &'a mut Port;
+    type IntoIter = slice::IterMut<'a, Port>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.collection.iter_mut()
     }
 }
 
-pub struct Port<'a> {
-    registers: &'a Spinlock<Registers>,
+pub struct Port {
+    registers: Rc<RefCell<Registers>>,
     index: usize,
 }
-impl<'a> Port<'a> {
+impl<'a> Port {
     pub fn reset_if_connected(&mut self) {
         if self.connected() {
             self.reset();
         }
     }
 
-    fn new(registers: &'a Spinlock<Registers>, index: usize) -> Self {
+    fn new(registers: Rc<RefCell<Registers>>, index: usize) -> Self {
         Self { registers, index }
     }
 
@@ -65,7 +64,7 @@ impl<'a> Port<'a> {
     }
 
     fn start_resetting(&mut self) {
-        let port_rg = &mut self.registers.lock().hc_operational.port_registers;
+        let port_rg = &mut self.registers.borrow_mut().hc_operational.port_registers;
         port_rg.update(self.index, |rg| rg.port_sc.set_port_reset(true))
     }
 
@@ -77,7 +76,7 @@ impl<'a> Port<'a> {
     }
 
     fn read_port_rg(&self) -> PortRegisters {
-        let port_rg = &self.registers.lock().hc_operational.port_registers;
+        let port_rg = &self.registers.borrow().hc_operational.port_registers;
         port_rg.read(self.index)
     }
 }

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -10,9 +10,9 @@ pub struct Collection {
     collection: Vec<Port>,
 }
 impl<'a> Collection {
-    pub fn new(registers: Rc<RefCell<Registers>>) -> Self {
+    pub fn new(registers: &Rc<RefCell<Registers>>) -> Self {
         let mut collection = Vec::new();
-        for i in 0..Self::num_of_ports(registers.clone()) {
+        for i in 0..Self::num_of_ports(&registers) {
             collection.push(Port::new(registers.clone(), i));
         }
 
@@ -25,7 +25,7 @@ impl<'a> Collection {
         }
     }
 
-    fn num_of_ports(registers: Rc<RefCell<Registers>>) -> usize {
+    fn num_of_ports(registers: &Rc<RefCell<Registers>>) -> usize {
         let params1 = &registers.borrow().hc_capability.hcs_params_1;
         params1.read().max_ports().into()
     }


### PR DESCRIPTION
To share this with multiple tasks. `Rc` may be replaced with `Arc`.
`RefCell` may be replaced with `Spinlock` in order to wait until the
lock is freed while using `RefCell` will panic.

bors r+
