### PR TITLE
Define the command runner

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -41,3 +41,4 @@ futures-util = { version = "0.3.4", default-features = false, features = ["alloc
 screen_layer = "0.1.0"
 os_units = "0.2.0"
 bitfield = "0.13.2"
+futures-intrusive = { version = "0.3.1", default-features = false}

--- a/kernel/src/device/pci/xhci/command_runner.rs
+++ b/kernel/src/device/pci/xhci/command_runner.rs
@@ -97,14 +97,14 @@ impl CommandCompletionReceiver {
         *self
             .trbs
             .get_mut(&addr_to_trb)
-            .ok_or_else(|| Error::NoSuchAddress)? = Some(trb);
+            .ok_or(Error::NoSuchAddress)? = Some(trb);
         Ok(())
     }
 
     fn wake_receiver(&mut self, addr_to_trb: PhysAddr) -> Result<(), Error> {
         self.wakers
             .get_mut(&addr_to_trb)
-            .ok_or_else(|| Error::NoSuchAddress)?
+            .ok_or(Error::NoSuchAddress)?
             .borrow_mut()
             .wake();
         Ok(())

--- a/kernel/src/device/pci/xhci/command_runner.rs
+++ b/kernel/src/device/pci/xhci/command_runner.rs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use {
+    super::ring::{command, trb::CommandComplete},
+    alloc::{collections::BTreeMap, rc::Rc},
+    core::{
+        cell::RefCell,
+        future::Future,
+        pin::Pin,
+        task::{Context, Poll},
+    },
+    futures_util::task::AtomicWaker,
+    x86_64::PhysAddr,
+};
+
+pub struct Runner {
+    ring: Rc<RefCell<command::Ring>>,
+    receiver: Rc<RefCell<CommandCompletionReceiver>>,
+    waker: Rc<RefCell<AtomicWaker>>,
+}
+impl Runner {
+    pub fn new(
+        ring: Rc<RefCell<command::Ring>>,
+        receiver: Rc<RefCell<CommandCompletionReceiver>>,
+    ) -> Self {
+        Self {
+            ring,
+            receiver,
+            waker: Rc::new(RefCell::new(AtomicWaker::new())),
+        }
+    }
+
+    pub async fn noop(&mut self) -> Result<(), command::Error> {
+        let addr_to_trb = self.ring.borrow_mut().send_noop()?;
+        self.register_to_receiver(addr_to_trb);
+        self.get_trb(addr_to_trb).await;
+        Ok(())
+    }
+
+    fn register_to_receiver(&mut self, addr_to_trb: PhysAddr) {
+        self.receiver
+            .borrow_mut()
+            .add_entry(addr_to_trb, self.waker.clone());
+    }
+
+    async fn get_trb(&mut self, addr_to_trb: PhysAddr) -> CommandComplete {
+        ReceiveFuture::new(addr_to_trb, self.receiver.clone(), self.waker.clone()).await
+    }
+}
+
+pub struct CommandCompletionReceiver {
+    trbs: BTreeMap<PhysAddr, Option<CommandComplete>>,
+    wakers: BTreeMap<PhysAddr, Rc<RefCell<AtomicWaker>>>,
+}
+impl CommandCompletionReceiver {
+    pub fn new() -> Self {
+        Self {
+            trbs: BTreeMap::new(),
+            wakers: BTreeMap::new(),
+        }
+    }
+
+    pub fn add_entry(&mut self, addr_to_trb: PhysAddr, waker: Rc<RefCell<AtomicWaker>>) {
+        self.insert_entry(addr_to_trb, waker).unwrap()
+    }
+
+    fn insert_entry(
+        &mut self,
+        addr_to_trb: PhysAddr,
+        waker: Rc<RefCell<AtomicWaker>>,
+    ) -> Result<(), Error> {
+        if self.trbs.insert(addr_to_trb, None).is_some() {
+            return Err(Error::AddrAlreadyRegistered);
+        }
+
+        if self.wakers.insert(addr_to_trb, waker).is_some() {
+            return Err(Error::AddrAlreadyRegistered);
+        }
+        Ok(())
+    }
+
+    pub fn receive(&mut self, trb: CommandComplete) {
+        if let Err(e) = self.insert_trb_and_wake_receiver(trb) {
+            panic!("Failed to receive a command completion trb: {:?}", e);
+        }
+    }
+
+    fn insert_trb_and_wake_receiver(&mut self, trb: CommandComplete) -> Result<(), Error> {
+        let addr_to_trb = PhysAddr::new(trb.addr_to_command_trb());
+        self.insert_trb(trb)?;
+        self.wake_receiver(addr_to_trb)?;
+        Ok(())
+    }
+
+    fn insert_trb(&mut self, trb: CommandComplete) -> Result<(), Error> {
+        let addr_to_trb = PhysAddr::new(trb.addr_to_command_trb());
+        *self
+            .trbs
+            .get_mut(&addr_to_trb)
+            .ok_or_else(|| Error::NoSuchAddress)? = Some(trb);
+        Ok(())
+    }
+
+    fn wake_receiver(&mut self, addr_to_trb: PhysAddr) -> Result<(), Error> {
+        self.wakers
+            .get_mut(&addr_to_trb)
+            .ok_or_else(|| Error::NoSuchAddress)?
+            .borrow_mut()
+            .wake();
+        Ok(())
+    }
+
+    fn trb_arrives(&self, addr_to_trb: PhysAddr) -> bool {
+        match self.trbs.get(&addr_to_trb) {
+            Some(trb) => trb.is_some(),
+            None => panic!("No such TRB with the address {:?}", addr_to_trb),
+        }
+    }
+
+    fn remove_entry(&mut self, addr_to_trb: PhysAddr) -> Option<CommandComplete> {
+        match self.trbs.remove(&addr_to_trb) {
+            Some(trb) => trb,
+            None => panic!("No such receiver with TRB address: {:?}", addr_to_trb),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    AddrAlreadyRegistered,
+    NoSuchAddress,
+}
+
+struct ReceiveFuture {
+    addr_to_trb: PhysAddr,
+    receiver: Rc<RefCell<CommandCompletionReceiver>>,
+    waker: Rc<RefCell<AtomicWaker>>,
+}
+
+impl ReceiveFuture {
+    fn new(
+        addr_to_trb: PhysAddr,
+        receiver: Rc<RefCell<CommandCompletionReceiver>>,
+        waker: Rc<RefCell<AtomicWaker>>,
+    ) -> Self {
+        Self {
+            addr_to_trb,
+            receiver,
+            waker,
+        }
+    }
+}
+impl Future for ReceiveFuture {
+    type Output = CommandComplete;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let waker = self.waker.clone();
+        let addr = self.addr_to_trb;
+        let receiver = &mut Pin::into_inner(self).receiver;
+
+        waker.borrow_mut().register(cx.waker());
+        if receiver.borrow_mut().trb_arrives(addr) {
+            waker.borrow_mut().take();
+            let trb = receiver.borrow_mut().remove_entry(addr).unwrap();
+            Poll::Ready(trb)
+        } else {
+            Poll::Pending
+        }
+    }
+}

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+mod command_runner;
 mod dcbaa;
 mod port;
 mod register;
@@ -7,8 +8,9 @@ mod ring;
 
 use {
     super::config::bar,
-    crate::multitask::task,
+    crate::multitask::task::{self, Task},
     alloc::rc::Rc,
+    command_runner::{CommandCompletionReceiver, Runner},
     core::cell::RefCell,
     dcbaa::DeviceContextBaseAddressArray,
     register::Registers,
@@ -17,13 +19,17 @@ use {
 
 pub async fn task(task_collection: Rc<RefCell<task::Collection>>) {
     let registers = Rc::new(RefCell::new(iter_devices().next().unwrap()));
-    let (_xhc, event_ring, mut command_ring, _dcbaa, port_task_spawner) =
-        init(&registers, task_collection);
-    command_ring.send_noop().unwrap();
+    let (_xhc, event_ring, _dcbaa, port_task_spawner, command_completion_receiver) =
+        init(&registers, task_collection.clone());
 
     port_task_spawner.spawn_tasks();
 
-    event::task(event_ring).await;
+    task_collection
+        .borrow_mut()
+        .add_task_as_woken(Task::new(event::task(
+            event_ring,
+            command_completion_receiver,
+        )));
 }
 
 fn init(
@@ -32,25 +38,30 @@ fn init(
 ) -> (
     Xhc,
     event::Ring,
-    command::Ring,
     DeviceContextBaseAddressArray,
     port::TaskSpawner,
+    Rc<RefCell<CommandCompletionReceiver>>,
 ) {
     let mut xhc = Xhc::new(registers.clone());
     let mut event_ring = event::Ring::new(registers.clone());
-    let mut command_ring = command::Ring::new(registers.clone());
+    let command_ring = Rc::new(RefCell::new(command::Ring::new(registers.clone())));
     let dcbaa = DeviceContextBaseAddressArray::new(registers.clone());
-    let ports = port::TaskSpawner::new(registers.clone(), task_collection);
+    let command_completion_receiver = Rc::new(RefCell::new(CommandCompletionReceiver::new()));
+    let command_runner = Rc::new(RefCell::new(Runner::new(
+        command_ring.clone(),
+        command_completion_receiver.clone(),
+    )));
+    let ports = port::TaskSpawner::new(command_runner, registers.clone(), task_collection);
 
     xhc.init();
 
     event_ring.init();
-    command_ring.init();
+    command_ring.borrow_mut().init();
     dcbaa.init();
 
     xhc.run();
 
-    (xhc, event_ring, command_ring, dcbaa, ports)
+    (xhc, event_ring, dcbaa, ports, command_completion_receiver)
 }
 
 pub struct Xhc {

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -22,7 +22,7 @@ pub async fn task(task_collection: Rc<RefCell<task::Collection>>) {
     let registers = Rc::new(RefCell::new(iter_devices().next().unwrap()));
     let (_xhc, event_ring, mut command_ring, _dcbaa, port_task_spawner) =
         init(&registers, task_collection);
-    command_ring.send_noop();
+    command_ring.send_noop().unwrap();
 
     port_task_spawner.spawn_tasks();
 

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -13,6 +13,7 @@ use {
     command_runner::{CommandCompletionReceiver, Runner},
     core::cell::RefCell,
     dcbaa::DeviceContextBaseAddressArray,
+    futures_intrusive::sync::LocalMutex,
     register::Registers,
     ring::{command, event},
 };
@@ -47,10 +48,10 @@ fn init(
     let command_ring = Rc::new(RefCell::new(command::Ring::new(registers.clone())));
     let dcbaa = DeviceContextBaseAddressArray::new(registers.clone());
     let command_completion_receiver = Rc::new(RefCell::new(CommandCompletionReceiver::new()));
-    let command_runner = Rc::new(RefCell::new(Runner::new(
-        command_ring.clone(),
-        command_completion_receiver.clone(),
-    )));
+    let command_runner = Rc::new(LocalMutex::new(
+        Runner::new(command_ring.clone(), command_completion_receiver.clone()),
+        false,
+    ));
     let ports = port::TaskSpawner::new(command_runner, registers.clone(), task_collection);
 
     xhc.init();

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -1,27 +1,35 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use {
-    super::register::{hc_operational::PortRegisters, Registers},
+    super::{
+        command_runner::Runner,
+        register::{hc_operational::PortRegisters, Registers},
+    },
     crate::multitask::task::{self, Task},
     alloc::rc::Rc,
     core::cell::RefCell,
 };
 
-async fn task(mut port: Port) {
+async fn task(mut port: Port, command_runner: Rc<RefCell<Runner>>) {
     info!("This is a task of port {}", port.index);
     port.reset_if_connected();
+    command_runner.borrow_mut().noop().await.unwrap();
+    info!("NOOP");
 }
 
 pub struct TaskSpawner {
+    command_runner: Rc<RefCell<Runner>>,
     registers: Rc<RefCell<Registers>>,
     task_collection: Rc<RefCell<task::Collection>>,
 }
 impl<'a> TaskSpawner {
     pub fn new(
+        command_runner: Rc<RefCell<Runner>>,
         registers: Rc<RefCell<Registers>>,
         task_collection: Rc<RefCell<task::Collection>>,
     ) -> Self {
         Self {
+            command_runner,
             registers,
             task_collection,
         }
@@ -33,7 +41,7 @@ impl<'a> TaskSpawner {
             if port.connected() {
                 self.task_collection
                     .borrow_mut()
-                    .add_task_as_woken(Task::new(task(port)));
+                    .add_task_as_woken(Task::new(task(port, self.command_runner.clone())));
             }
         }
     }

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -8,23 +8,24 @@ use {
     crate::multitask::task::{self, Task},
     alloc::rc::Rc,
     core::cell::RefCell,
+    futures_intrusive::sync::LocalMutex,
 };
 
-async fn task(mut port: Port, command_runner: Rc<RefCell<Runner>>) {
+async fn task(mut port: Port, command_runner: Rc<LocalMutex<Runner>>) {
     info!("This is a task of port {}", port.index);
     port.reset_if_connected();
-    command_runner.borrow_mut().noop().await.unwrap();
+    command_runner.lock().await.noop().await.unwrap();
     info!("NOOP");
 }
 
 pub struct TaskSpawner {
-    command_runner: Rc<RefCell<Runner>>,
+    command_runner: Rc<LocalMutex<Runner>>,
     registers: Rc<RefCell<Registers>>,
     task_collection: Rc<RefCell<task::Collection>>,
 }
 impl<'a> TaskSpawner {
     pub fn new(
-        command_runner: Rc<RefCell<Runner>>,
+        command_runner: Rc<LocalMutex<Runner>>,
         registers: Rc<RefCell<Registers>>,
         task_collection: Rc<RefCell<task::Collection>>,
     ) -> Self {

--- a/kernel/src/device/pci/xhci/ring/mod.rs
+++ b/kernel/src/device/pci/xhci/ring/mod.rs
@@ -3,7 +3,7 @@
 pub mod command;
 pub mod event;
 mod raw;
-mod trb;
+pub mod trb;
 
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CycleBit(bool);

--- a/kernel/src/device/pci/xhci/ring/trb.rs
+++ b/kernel/src/device/pci/xhci/ring/trb.rs
@@ -76,6 +76,7 @@ bitfield! {
     #[repr(transparent)]
     pub struct CommandComplete(u128);
     impl Debug;
+    pub u64, addr_to_command_trb, _: 63, 0;
     completion_code, _: 64+31,64+24;
 }
 impl CommandComplete {


### PR DESCRIPTION
- chore: `send_noop` returns the address to noop trb
- chore: add command runner
- refactor: use `ok_or`
- fix: resolve dead lock

bors r+
Fixes: #317 