### PR TITLE
Allocate input context data

### DIFF
--- a/kernel/src/device/pci/xhci/device_slot.rs
+++ b/kernel/src/device/pci/xhci/device_slot.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pub struct InputContext {
+    input_control_context: InputControlContext,
+    endpoint_context: [EndpointContext; 32],
+}
+
+#[repr(transparent)]
+pub struct InputControlContext([u32; 8]);
+
+#[repr(transparent)]
+pub struct EndpointContext([u32; 8]);

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -2,6 +2,7 @@
 
 mod command_runner;
 mod dcbaa;
+mod device_slot;
 mod port;
 mod register;
 mod ring;

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -3,9 +3,13 @@
 use {
     super::{
         command_runner::Runner,
+        device_slot::InputContext,
         register::{hc_operational::PortRegisters, Registers},
     },
-    crate::multitask::task::{self, Task},
+    crate::{
+        mem::allocator::page_box::PageBox,
+        multitask::task::{self, Task},
+    },
     alloc::rc::Rc,
     core::cell::RefCell,
     futures_intrusive::sync::LocalMutex,
@@ -61,6 +65,7 @@ impl<'a> TaskSpawner {
 pub struct Port {
     registers: Rc<RefCell<Registers>>,
     index: usize,
+    input_context: PageBox<InputContext>,
 }
 impl<'a> Port {
     pub fn reset_if_connected(&mut self) {
@@ -70,7 +75,11 @@ impl<'a> Port {
     }
 
     fn new(registers: Rc<RefCell<Registers>>, index: usize) -> Self {
-        Self { registers, index }
+        Self {
+            registers,
+            index,
+            input_context: PageBox::new(),
+        }
     }
 
     fn connected(&self) -> bool {

--- a/kernel/src/mem/allocator/page_box.rs
+++ b/kernel/src/mem/allocator/page_box.rs
@@ -24,6 +24,20 @@ pub struct PageBox<T: ?Sized> {
     bytes: Bytes,
     _marker: PhantomData<T>,
 }
+impl<T> PageBox<T> {
+    pub fn new() -> Self {
+        let bytes = Bytes::new(mem::size_of::<T>());
+        let virt = Self::allocate_pages(bytes.as_num_of_pages());
+
+        let mut page_box = Self {
+            virt,
+            bytes,
+            _marker: PhantomData::<T>,
+        };
+        page_box.write_all_bytes_with_zero();
+        page_box
+    }
+}
 impl<T> PageBox<[T]> {
     pub fn new_slice(num_of_elements: usize) -> Self {
         let bytes = Bytes::new(mem::size_of::<T>() * num_of_elements);

--- a/kernel/src/mem/allocator/page_box.rs
+++ b/kernel/src/mem/allocator/page_box.rs
@@ -27,29 +27,13 @@ pub struct PageBox<T: ?Sized> {
 impl<T> PageBox<T> {
     pub fn new() -> Self {
         let bytes = Bytes::new(mem::size_of::<T>());
-        let virt = Self::allocate_pages(bytes.as_num_of_pages());
-
-        let mut page_box = Self {
-            virt,
-            bytes,
-            _marker: PhantomData::<T>,
-        };
-        page_box.write_all_bytes_with_zero();
-        page_box
+        Self::new_from_bytes(bytes)
     }
 }
 impl<T> PageBox<[T]> {
     pub fn new_slice(num_of_elements: usize) -> Self {
         let bytes = Bytes::new(mem::size_of::<T>() * num_of_elements);
-        let virt = Self::allocate_pages(bytes.as_num_of_pages());
-
-        let mut page_box = Self {
-            virt,
-            bytes,
-            _marker: PhantomData::<[T]>,
-        };
-        page_box.write_all_bytes_with_zero();
-        page_box
+        Self::new_from_bytes(bytes)
     }
 
     pub fn phys_addr(&self) -> PhysAddr {
@@ -72,6 +56,18 @@ impl<T> DerefMut for PageBox<[T]> {
     }
 }
 impl<T: ?Sized> PageBox<T> {
+    fn new_from_bytes(bytes: Bytes) -> Self {
+        let virt = Self::allocate_pages(bytes.as_num_of_pages());
+
+        let mut page_box = Self {
+            virt,
+            bytes,
+            _marker: PhantomData,
+        };
+        page_box.write_all_bytes_with_zero();
+        page_box
+    }
+
     fn write_all_bytes_with_zero(&mut self) {
         unsafe {
             core::ptr::write_bytes(self.virt.as_mut_ptr::<u8>(), 0, self.bytes.as_usize());


### PR DESCRIPTION
- chore: define `InputContext`
- refactor: define `new_from_bytes`

bors r+
