### PR TITLE
Initialize the input control context

### DIFF
--- a/kernel/src/device/pci/xhci/device_slot.rs
+++ b/kernel/src/device/pci/xhci/device_slot.rs
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 pub struct InputContext {
-    input_control_context: InputControlContext,
+    pub input_control_context: InputControlContext,
     endpoint_context: [EndpointContext; 32],
 }
 
 #[repr(transparent)]
 pub struct InputControlContext([u32; 8]);
+impl InputControlContext {
+    pub fn set_aflag(&mut self, index: usize) {
+        assert!(index < 32);
+        self.0[1] |= 1 << index;
+    }
+}
 
 #[repr(transparent)]
 pub struct EndpointContext([u32; 8]);

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -25,6 +25,9 @@ async fn task(mut port: Port, command_runner: Rc<LocalMutex<Runner>>) {
         .await
         .unwrap();
     info!("Slot ID: {}", slot_id);
+
+    port.input_context.input_control_context.set_aflag(0);
+    port.input_context.input_control_context.set_aflag(1);
 }
 
 pub struct TaskSpawner {

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -71,7 +71,7 @@ pub struct Port {
     input_context: PageBox<InputContext>,
 }
 impl<'a> Port {
-    pub fn reset_if_connected(&mut self) {
+    fn reset_if_connected(&mut self) {
         if self.connected() {
             self.reset();
         }

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -26,8 +26,7 @@ async fn task(mut port: Port, command_runner: Rc<LocalMutex<Runner>>) {
         .unwrap();
     info!("Slot ID: {}", slot_id);
 
-    port.input_context.input_control_context.set_aflag(0);
-    port.input_context.input_control_context.set_aflag(1);
+    port.init_input_control_context();
 }
 
 pub struct TaskSpawner {
@@ -104,6 +103,11 @@ impl<'a> Port {
             let port_rg = self.read_port_rg();
             !port_rg.port_sc.port_reset_changed()
         } {}
+    }
+
+    fn init_input_control_context(&mut self) {
+        self.input_context.input_control_context.set_aflag(0);
+        self.input_context.input_control_context.set_aflag(1);
     }
 
     fn read_port_rg(&self) -> PortRegisters {

--- a/kernel/src/mem/allocator/page_box.rs
+++ b/kernel/src/mem/allocator/page_box.rs
@@ -30,6 +30,22 @@ impl<T> PageBox<T> {
         Self::new_from_bytes(bytes)
     }
 }
+impl<T> Deref for PageBox<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        // Safety: This operation is safe because the memory region `virt` points is allocated and
+        // is not used by the others.
+        unsafe { &*self.virt.as_ptr() }
+    }
+}
+impl<T> DerefMut for PageBox<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // Safety: This operation is safe because the memory region `virt` points is allocated and
+        // is not used by the others.
+        unsafe { &mut *self.virt.as_mut_ptr() }
+    }
+}
+
 impl<T> PageBox<[T]> {
     pub fn new_slice(num_of_elements: usize) -> Self {
         let bytes = Bytes::new(mem::size_of::<T>() * num_of_elements);


### PR DESCRIPTION
- chore: implement `DerefMut` and `Deref` for page box
- chore: init input control context
- refactor: remove an unnecessary `pub`
- refactor: define `init_input_control_context`

bors r+
