### PR TITLE
Allocate transfer ring

### DIFF
--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -5,6 +5,7 @@ use {
         command_runner::Runner,
         context,
         register::{hc_operational::PortRegisters, Registers},
+        ring::transfer,
     },
     crate::{
         mem::allocator::page_box::PageBox,
@@ -70,6 +71,7 @@ pub struct Port {
     index: usize,
     input_context: PageBox<context::Input>,
     input_slot_context: PageBox<context::Slot>,
+    transfer_ring: transfer::Ring,
 }
 impl<'a> Port {
     fn reset_if_connected(&mut self) {
@@ -80,10 +82,11 @@ impl<'a> Port {
 
     fn new(registers: Rc<RefCell<Registers>>, index: usize) -> Self {
         Self {
-            registers,
+            registers: registers.clone(),
             index,
             input_context: PageBox::new(context::Input::null()),
             input_slot_context: PageBox::new(context::Slot::null()),
+            transfer_ring: transfer::Ring::new(registers.clone()),
         }
     }
 

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -73,7 +73,7 @@ pub struct Port {
     input_slot_context: PageBox<context::Slot>,
     transfer_ring: transfer::Ring,
 }
-impl<'a> Port {
+impl Port {
     fn reset_if_connected(&mut self) {
         if self.connected() {
             self.reset();

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -86,7 +86,7 @@ impl Port {
             index,
             input_context: PageBox::new(context::Input::null()),
             input_slot_context: PageBox::new(context::Slot::null()),
-            transfer_ring: transfer::Ring::new(registers.clone()),
+            transfer_ring: transfer::Ring::new(registers),
         }
     }
 

--- a/kernel/src/device/pci/xhci/ring/mod.rs
+++ b/kernel/src/device/pci/xhci/ring/mod.rs
@@ -3,6 +3,7 @@
 pub mod command;
 pub mod event;
 mod raw;
+pub mod transfer;
 pub mod trb;
 
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]

--- a/kernel/src/device/pci/xhci/ring/transfer.rs
+++ b/kernel/src/device/pci/xhci/ring/transfer.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use {
+    super::{super::Registers, raw, CycleBit},
+    alloc::rc::Rc,
+    core::cell::RefCell,
+};
+
+const SIZE_OF_RING: usize = 256;
+
+pub struct Ring {
+    raw: raw::Ring,
+    enqueue_ptr: usize,
+    cycle_bit: CycleBit,
+    registers: Rc<RefCell<Registers>>,
+}
+impl Ring {
+    pub fn new(registers: Rc<RefCell<Registers>>) -> Self {
+        Self {
+            raw: raw::Ring::new(SIZE_OF_RING),
+            enqueue_ptr: 0,
+            cycle_bit: CycleBit::new(true),
+            registers,
+        }
+    }
+}


### PR DESCRIPTION
- chore: allocate transfer ring
- refactor: remove an unnecessary lifetime notation

bors r+
