### PR TITLE
Determine which ports are avilable

### DIFF
--- a/kernel/src/device/pci/ahci/ahc/registers/generic.rs
+++ b/kernel/src/device/pci/ahci/ahc/registers/generic.rs
@@ -6,14 +6,16 @@ use {
 
 pub struct Generic {
     pub ghc: Accessor<GlobalHbaControl>,
+    pub pi: Accessor<PortsImplemented>,
     pub bohc: Accessor<BiosOsHandoffControlAndStatus>,
 }
 impl Generic {
     pub fn new(abar: AchiBaseAddr) -> Self {
         let ghc = Accessor::new(abar.into(), Bytes::new(0x04));
+        let pi = Accessor::new(abar.into(), Bytes::new(0x0c));
         let bohc = Accessor::new(abar.into(), Bytes::new(0x28));
 
-        Self { ghc, bohc }
+        Self { ghc, pi, bohc }
     }
 }
 
@@ -31,3 +33,7 @@ bitfield! {
     pub os_owned_semaphore, set_os_owned_semaphore: 1;
     pub bios_owned_semaphore, _: 0;
 }
+
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct PortsImplemented(u32);

--- a/kernel/src/device/pci/ahci/ahc/registers/generic.rs
+++ b/kernel/src/device/pci/ahci/ahc/registers/generic.rs
@@ -36,4 +36,4 @@ bitfield! {
 
 #[repr(transparent)]
 #[derive(Debug)]
-pub struct PortsImplemented(u32);
+pub struct PortsImplemented(pub u32);

--- a/kernel/src/device/pci/ahci/mod.rs
+++ b/kernel/src/device/pci/ahci/mod.rs
@@ -10,5 +10,6 @@ pub async fn task() {
         None => return,
     };
     ahc.place_into_minimally_initialized_state();
+    ahc.print_available_ports();
     ahc.get_ownership_from_bios();
 }


### PR DESCRIPTION
- chore: add `pi` as a member
- chore: print the available ports

bors r+
