### PR TITLE
Fetch the number of command slote supported by HBA

### DIFF
--- a/kernel/src/device/pci/ahci/ahc.rs
+++ b/kernel/src/device/pci/ahci/ahc.rs
@@ -20,6 +20,11 @@ impl Ahc {
         self.wait_until_ownership_is_moved();
     }
 
+    pub fn num_of_supported_command_slots(&self) -> u32 {
+        let registers = &self.registers.borrow();
+        registers.generic.cap.read().num_of_command_slots()
+    }
+
     fn request_ownership_to_bios(&mut self) {
         let registers = &mut self.registers.borrow_mut();
         let bohc = &mut registers.generic.bohc;

--- a/kernel/src/device/pci/ahci/mod.rs
+++ b/kernel/src/device/pci/ahci/mod.rs
@@ -39,6 +39,10 @@ fn fetch_registers() -> Option<Registers> {
 fn place_into_minimally_initialized_state(ahc: &mut Ahc, ports: &mut port::Collection) {
     ahc.indicate_system_software_is_ahci_aware();
     ports.idle_all_ports();
+    info!(
+        "Number of command slots supported: {}",
+        ahc.num_of_supported_command_slots() + 1
+    );
 }
 
 #[derive(Copy, Clone)]

--- a/kernel/src/device/pci/ahci/registers/generic.rs
+++ b/kernel/src/device/pci/ahci/registers/generic.rs
@@ -25,7 +25,7 @@ bitfield! {
     #[repr(transparent)]
     pub struct HbaCapability(u32);
     impl Debug;
-    num_of_command_slots, _: 12, 8;
+    pub num_of_command_slots, _: 12, 8;
 }
 
 bitfield! {

--- a/kernel/src/device/pci/ahci/registers/generic.rs
+++ b/kernel/src/device/pci/ahci/registers/generic.rs
@@ -5,18 +5,27 @@ use {
 };
 
 pub struct Generic {
+    pub cap: Accessor<HbaCapability>,
     pub ghc: Accessor<GlobalHbaControl>,
     pub pi: Accessor<PortsImplemented>,
     pub bohc: Accessor<BiosOsHandoffControlAndStatus>,
 }
 impl Generic {
     pub fn new(abar: AchiBaseAddr) -> Self {
+        let cap = Accessor::new(abar.into(), Bytes::new(0x00));
         let ghc = Accessor::new(abar.into(), Bytes::new(0x04));
         let pi = Accessor::new(abar.into(), Bytes::new(0x0c));
         let bohc = Accessor::new(abar.into(), Bytes::new(0x28));
 
-        Self { ghc, pi, bohc }
+        Self { cap, ghc, pi, bohc }
     }
+}
+
+bitfield! {
+    #[repr(transparent)]
+    pub struct HbaCapability(u32);
+    impl Debug;
+    num_of_command_slots, _: 12, 8;
 }
 
 bitfield! {


### PR DESCRIPTION
- chore: define `HbaCapability`
- chore: fetch the number of command slots supported by hba

bors r+
