### PR TITLE
Start command list processing

### DIFF
--- a/kernel/src/device/pci/ahci/mod.rs
+++ b/kernel/src/device/pci/ahci/mod.rs
@@ -19,8 +19,8 @@ pub async fn task() {
         None => return,
     };
 
-    place_into_minimally_initialized_state(&mut ahc, &mut ports);
     ahc.get_ownership_from_bios();
+    place_into_minimally_initialized_state(&mut ahc, &mut ports);
     ports.start();
 }
 

--- a/kernel/src/device/pci/ahci/mod.rs
+++ b/kernel/src/device/pci/ahci/mod.rs
@@ -21,6 +21,7 @@ pub async fn task() {
 
     place_into_minimally_initialized_state(&mut ahc, &mut ports);
     ahc.get_ownership_from_bios();
+    ports.start();
 }
 
 fn init() -> Option<(Ahc, port::Collection)> {

--- a/kernel/src/device/pci/ahci/port/mod.rs
+++ b/kernel/src/device/pci/ahci/port/mod.rs
@@ -41,6 +41,12 @@ impl Collection {
         }
     }
 
+    pub fn start(&mut self) {
+        for port in self.iter_mut() {
+            port.start();
+        }
+    }
+
     fn iter_mut(&mut self) -> impl Iterator<Item = &mut Port> {
         self.0.iter_mut()
     }
@@ -119,6 +125,35 @@ impl Port {
         // Refer to P.31 and P.104 of Serial ATA AHCI 1.3.1 Specification
         const BIT_MASK: u32 = 0x07ff_0f03;
         self.edit_port_rg(|rg| rg.serr.update(|serr| serr.0 = BIT_MASK));
+    }
+
+    fn start(&mut self) {
+        if self.ready_to_start() {
+            self.start_processing();
+        }
+    }
+
+    fn ready_to_start(&self) -> bool {
+        !self.command_list_is_running() && self.fis_receive_enabled() && self.device_is_present()
+    }
+
+    fn command_list_is_running(&self) -> bool {
+        self.parse_port_rg(|r| r.cmd.read().command_list_running())
+    }
+
+    fn fis_receive_enabled(&self) -> bool {
+        self.parse_port_rg(|r| r.cmd.read().fis_receive_enable())
+    }
+
+    fn device_is_present(&self) -> bool {
+        self.parse_port_rg(|r| {
+            r.ssts.read().device_detection() == 3
+                || [2, 6, 8].contains(&r.ssts.read().interface_power_management())
+        })
+    }
+
+    fn start_processing(&mut self) {
+        self.edit_port_rg(|r| r.cmd.update(|r| r.set_start_bit(true)))
     }
 
     fn parse_port_rg<T, U>(&self, f: T) -> U

--- a/kernel/src/device/pci/ahci/port/mod.rs
+++ b/kernel/src/device/pci/ahci/port/mod.rs
@@ -53,7 +53,7 @@ pub struct Port {
     index: usize,
 }
 impl Port {
-    pub fn idle(&mut self) {
+    fn idle(&mut self) {
         self.edit_port_rg(|rg| {
             rg.cmd.update(|cmd| {
                 cmd.set_start_bit(false);

--- a/kernel/src/device/pci/ahci/registers/port.rs
+++ b/kernel/src/device/pci/ahci/registers/port.rs
@@ -13,6 +13,7 @@ pub struct Registers {
     pub fb: Accessor<PortxFisBaseAddress>,
     pub cmd: Accessor<PortxCommandAndStatus>,
     pub tfd: Accessor<PortxTaskFileData>,
+    pub ssts: Accessor<PortxSerialAtaStatus>,
     pub serr: Accessor<PortxSerialAtaError>,
 }
 impl Registers {
@@ -35,6 +36,7 @@ impl Registers {
         let fb = Accessor::new(base_addr, Bytes::new(0x08));
         let cmd = Accessor::new(base_addr, Bytes::new(0x18));
         let tfd = Accessor::new(base_addr, Bytes::new(0x20));
+        let ssts = Accessor::new(base_addr, Bytes::new(0x28));
         let serr = Accessor::new(base_addr, Bytes::new(0x30));
 
         Self {
@@ -42,6 +44,7 @@ impl Registers {
             fb,
             cmd,
             tfd,
+            ssts,
             serr,
         }
     }
@@ -79,6 +82,14 @@ bitfield! {
     impl Debug;
     busy, _: 14;
     data_transfer_is_required, _: 10;
+}
+
+bitfield! {
+    #[repr(transparent)]
+    pub struct PortxSerialAtaStatus(u32);
+    impl Debug;
+    device_detection, _: 3, 0;
+    interface_power_management, _: 11, 8;
 }
 
 #[repr(transparent)]

--- a/kernel/src/device/pci/ahci/registers/port.rs
+++ b/kernel/src/device/pci/ahci/registers/port.rs
@@ -30,17 +30,12 @@ impl Registers {
     fn fetch(abar: AchiBaseAddr, port_index: usize) -> Self {
         let base_addr = Self::base_addr_to_registers(abar, port_index);
 
-        let px_clb = Accessor::new(base_addr, Bytes::new(0x00));
-        let px_fb = Accessor::new(base_addr, Bytes::new(0x08));
-        let px_cmd = Accessor::new(base_addr, Bytes::new(0x18));
-        let px_serr = Accessor::new(base_addr, Bytes::new(0x30));
+        let clb = Accessor::new(base_addr, Bytes::new(0x00));
+        let fb = Accessor::new(base_addr, Bytes::new(0x08));
+        let cmd = Accessor::new(base_addr, Bytes::new(0x18));
+        let serr = Accessor::new(base_addr, Bytes::new(0x30));
 
-        Self {
-            clb: px_clb,
-            fb: px_fb,
-            cmd: px_cmd,
-            serr: px_serr,
-        }
+        Self { clb, fb, cmd, serr }
     }
 
     fn base_addr_to_registers(abar: AchiBaseAddr, port_index: usize) -> PhysAddr {

--- a/kernel/src/device/pci/ahci/registers/port.rs
+++ b/kernel/src/device/pci/ahci/registers/port.rs
@@ -12,6 +12,7 @@ pub struct Registers {
     pub clb: Accessor<PortxCommandListBaseAddress>,
     pub fb: Accessor<PortxFisBaseAddress>,
     pub cmd: Accessor<PortxCommandAndStatus>,
+    pub tfd: Accessor<PortxTaskFileData>,
     pub serr: Accessor<PortxSerialAtaError>,
 }
 impl Registers {
@@ -33,9 +34,16 @@ impl Registers {
         let clb = Accessor::new(base_addr, Bytes::new(0x00));
         let fb = Accessor::new(base_addr, Bytes::new(0x08));
         let cmd = Accessor::new(base_addr, Bytes::new(0x18));
+        let tfd = Accessor::new(base_addr, Bytes::new(0x20));
         let serr = Accessor::new(base_addr, Bytes::new(0x30));
 
-        Self { clb, fb, cmd, serr }
+        Self {
+            clb,
+            fb,
+            cmd,
+            tfd,
+            serr,
+        }
     }
 
     fn base_addr_to_registers(abar: AchiBaseAddr, port_index: usize) -> PhysAddr {
@@ -63,6 +71,14 @@ impl PortxCommandListBaseAddress {
         assert!(addr.as_u64().trailing_zeros() >= 10);
         self.0 = addr.as_u64();
     }
+}
+
+bitfield! {
+    #[repr(transparent)]
+    pub struct PortxTaskFileData(u32);
+    impl Debug;
+    busy, _: 14;
+    data_transfer_is_required, _: 10;
 }
 
 #[repr(transparent)]

--- a/kernel/src/device/pci/ahci/registers/port.rs
+++ b/kernel/src/device/pci/ahci/registers/port.rs
@@ -80,16 +80,16 @@ bitfield! {
     #[repr(transparent)]
     pub struct PortxTaskFileData(u32);
     impl Debug;
-    busy, _: 14;
-    data_transfer_is_required, _: 10;
+    pub busy, _: 14;
+    pub data_transfer_is_required, _: 10;
 }
 
 bitfield! {
     #[repr(transparent)]
     pub struct PortxSerialAtaStatus(u32);
     impl Debug;
-    device_detection, _: 3, 0;
-    interface_power_management, _: 11, 8;
+    pub device_detection, _: 3, 0;
+    pub interface_power_management, _: 11, 8;
 }
 
 #[repr(transparent)]


### PR DESCRIPTION
- refactor: remove unnecessary member specification
- chore: add `tfd` as a member
- chore: add @ssts` as a member
- chore: add `pub`s
- refactor: remove an unnecessary `pub`
- chore: start processing of each ahci ports
- chore: moving the ownership first

bors r+
