### PR TITLE
Spawn ahci port tasks

### DIFF
--- a/kernel/src/device/pci/ahci/ahc.rs
+++ b/kernel/src/device/pci/ahci/ahc.rs
@@ -10,6 +10,12 @@ impl Ahc {
         Self { registers }
     }
 
+    pub fn init(&mut self) {
+        self.get_ownership_from_bios();
+        self.reset();
+        self.indicate_system_software_is_ahci_aware();
+    }
+
     pub fn indicate_system_software_is_ahci_aware(&mut self) {
         let ghc = &mut self.registers.borrow_mut().generic.ghc;
         ghc.update(|ghc| ghc.set_ahci_enable(true));

--- a/kernel/src/device/pci/ahci/mod.rs
+++ b/kernel/src/device/pci/ahci/mod.rs
@@ -23,7 +23,7 @@ pub async fn task(task_collection: Rc<RefCell<task::Collection>>) {
     };
 
     ahc.init();
-    port::spawn_tasks(&registers, task_collection);
+    port::spawn_tasks(&registers, &task_collection);
 }
 
 fn init() -> Option<(Rc<RefCell<Registers>>, Ahc)> {

--- a/kernel/src/device/pci/ahci/mod.rs
+++ b/kernel/src/device/pci/ahci/mod.rs
@@ -19,7 +19,6 @@ pub async fn task() {
         None => return,
     };
 
-    ahc.get_ownership_from_bios();
     place_into_minimally_initialized_state(&mut ahc, &mut ports);
     ports.start();
 }
@@ -38,8 +37,7 @@ fn fetch_registers() -> Option<Registers> {
 }
 
 fn place_into_minimally_initialized_state(ahc: &mut Ahc, ports: &mut port::Collection) {
-    ahc.reset();
-    ahc.indicate_system_software_is_ahci_aware();
+    ahc.init();
     ports.init();
 }
 

--- a/kernel/src/device/pci/ahci/mod.rs
+++ b/kernel/src/device/pci/ahci/mod.rs
@@ -19,7 +19,8 @@ pub async fn task() {
         None => return,
     };
 
-    place_into_minimally_initialized_state(&mut ahc, &mut ports);
+    ahc.init();
+    ports.init();
     ports.start();
 }
 
@@ -34,11 +35,6 @@ fn init() -> Option<(Ahc, port::Collection)> {
 fn fetch_registers() -> Option<Registers> {
     let abar = AchiBaseAddr::new()?;
     Some(Registers::new(abar))
-}
-
-fn place_into_minimally_initialized_state(ahc: &mut Ahc, ports: &mut port::Collection) {
-    ahc.init();
-    ports.init();
 }
 
 #[derive(Copy, Clone)]

--- a/kernel/src/device/pci/ahci/mod.rs
+++ b/kernel/src/device/pci/ahci/mod.rs
@@ -40,9 +40,7 @@ fn fetch_registers() -> Option<Registers> {
 fn place_into_minimally_initialized_state(ahc: &mut Ahc, ports: &mut port::Collection) {
     ahc.reset();
     ahc.indicate_system_software_is_ahci_aware();
-    ports.idle_all_ports();
-    ports.register_command_lists_and_fis();
-    ports.clear_error_bits();
+    ports.init();
 }
 
 #[derive(Copy, Clone)]

--- a/kernel/src/device/pci/ahci/port/mod.rs
+++ b/kernel/src/device/pci/ahci/port/mod.rs
@@ -41,6 +41,12 @@ impl Collection {
         }
     }
 
+    pub fn init(&mut self) {
+        for port in self.iter_mut() {
+            port.init();
+        }
+    }
+
     pub fn start(&mut self) {
         for port in self.iter_mut() {
             port.start();
@@ -98,6 +104,12 @@ impl Port {
             command_list,
             index,
         }
+    }
+
+    fn init(&mut self) {
+        self.idle();
+        self.register_command_list_and_received_fis();
+        self.clear_error_bits();
     }
 
     fn register_command_list_and_received_fis(&mut self) {

--- a/kernel/src/device/pci/ahci/port/mod.rs
+++ b/kernel/src/device/pci/ahci/port/mod.rs
@@ -16,7 +16,7 @@ const MAX_PORTS: usize = 32;
 
 pub fn spawn_tasks(
     registers: &Rc<RefCell<Registers>>,
-    task_collection: Rc<RefCell<task::Collection>>,
+    task_collection: &Rc<RefCell<task::Collection>>,
 ) {
     (0..MAX_PORTS)
         .filter_map(|i| Port::new(registers.clone(), i))

--- a/kernel/src/device/pci/ahci/port/mod.rs
+++ b/kernel/src/device/pci/ahci/port/mod.rs
@@ -23,24 +23,6 @@ impl Collection {
         )
     }
 
-    pub fn idle_all_ports(&mut self) {
-        for port in self.iter_mut() {
-            port.idle();
-        }
-    }
-
-    pub fn clear_error_bits(&mut self) {
-        for port in self.iter_mut() {
-            port.clear_error_bits();
-        }
-    }
-
-    pub fn register_command_lists_and_fis(&mut self) {
-        for port in self.iter_mut() {
-            port.register_command_list_and_received_fis();
-        }
-    }
-
     pub fn init(&mut self) {
         for port in self.iter_mut() {
             port.init();

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -105,7 +105,7 @@ fn run_tasks() -> ! {
         .add_task_as_woken(Task::new(xhci::task(task_collection.clone())));
     task_collection
         .borrow_mut()
-        .add_task_as_woken(Task::new(ahci::task()));
+        .add_task_as_woken(Task::new(ahci::task(task_collection.clone())));
 
     let mut executor = Executor::new(task_collection);
     executor.run();


### PR DESCRIPTION
- refactor: define `ports.init`
- refactor: define `Ach::init`
- refactor: remove a function
- refactor: remove unnecessary methods
- chore: spawn port tasks

bors r+
