### PR TITLE
chore: add `output_device_context` as a member

### DIFF
--- a/kernel/src/device/pci/xhci/context.rs
+++ b/kernel/src/device/pci/xhci/context.rs
@@ -37,7 +37,7 @@ pub struct Device {
     ep_inout: [EndpointOutIn; 15],
 }
 impl Device {
-    fn null() -> Self {
+    pub fn null() -> Self {
         Self {
             slot: Slot::null(),
             ep_0: Endpoint::null(),

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -72,6 +72,7 @@ pub struct Port {
     index: usize,
     input_context: PageBox<context::Input>,
     input_slot_context: PageBox<context::Slot>,
+    output_device_context: PageBox<context::Device>,
     transfer_ring: transfer::Ring,
 }
 impl Port {
@@ -87,6 +88,7 @@ impl Port {
             index,
             input_context: PageBox::new(context::Input::null()),
             input_slot_context: PageBox::new(context::Slot::null()),
+            output_device_context: PageBox::new(context::Device::null()),
             transfer_ring: transfer::Ring::new(registers),
         }
     }


### PR DESCRIPTION
bors r+
