### PR TITLE
Write an address to DCBAA

### DIFF
--- a/kernel/src/device/pci/xhci/dcbaa.rs
+++ b/kernel/src/device/pci/xhci/dcbaa.rs
@@ -6,12 +6,12 @@ use {
 };
 
 pub struct DeviceContextBaseAddressArray {
-    arr: PageBox<[usize]>,
+    arr: PageBox<[PhysAddr]>,
     registers: Rc<RefCell<Registers>>,
 }
 impl<'a> DeviceContextBaseAddressArray {
     pub fn new(registers: Rc<RefCell<Registers>>) -> Self {
-        let arr = PageBox::new_slice(0, Self::num_of_slots(&registers));
+        let arr = PageBox::new_slice(PhysAddr::zero(), Self::num_of_slots(&registers));
         Self { arr, registers }
     }
 

--- a/kernel/src/device/pci/xhci/dcbaa.rs
+++ b/kernel/src/device/pci/xhci/dcbaa.rs
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use {
-    super::Registers, crate::mem::allocator::page_box::PageBox, alloc::rc::Rc, core::cell::RefCell,
+    super::Registers,
+    crate::mem::allocator::page_box::PageBox,
+    alloc::rc::Rc,
+    core::{
+        cell::RefCell,
+        ops::{Index, IndexMut},
+    },
     x86_64::PhysAddr,
 };
 
@@ -31,5 +37,16 @@ impl<'a> DeviceContextBaseAddressArray {
 
     fn phys_addr(&self) -> PhysAddr {
         self.arr.phys_addr()
+    }
+}
+impl Index<usize> for DeviceContextBaseAddressArray {
+    type Output = PhysAddr;
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.arr[index]
+    }
+}
+impl IndexMut<usize> for DeviceContextBaseAddressArray {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.arr[index]
     }
 }

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -24,9 +24,9 @@ use {
 pub async fn task(task_collection: Rc<RefCell<task::Collection>>) {
     let registers = Rc::new(RefCell::new(iter_devices().next().unwrap()));
     let (_xhc, event_ring, dcbaa, runner, command_completion_receiver) =
-        init(&registers, task_collection.clone());
+        init(&registers, &task_collection.clone());
 
-    port::spawn_tasks(runner, dcbaa, registers, task_collection.clone());
+    port::spawn_tasks(&runner, &dcbaa, &registers, &task_collection.clone());
 
     task_collection
         .borrow_mut()
@@ -38,7 +38,7 @@ pub async fn task(task_collection: Rc<RefCell<task::Collection>>) {
 
 fn init(
     registers: &Rc<RefCell<Registers>>,
-    task_collection: Rc<RefCell<task::Collection>>,
+    task_collection: &Rc<RefCell<task::Collection>>,
 ) -> (
     Xhc,
     event::Ring,

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -23,7 +23,7 @@ use {
 
 pub async fn task(task_collection: Rc<RefCell<task::Collection>>) {
     let registers = Rc::new(RefCell::new(iter_devices().next().unwrap()));
-    let (_xhc, event_ring, dcbaa, runner, command_completion_receiver) =
+    let (event_ring, dcbaa, runner, command_completion_receiver) =
         init(&registers, &task_collection.clone());
 
     port::spawn_tasks(&runner, &dcbaa, &registers, &task_collection.clone());
@@ -40,7 +40,6 @@ fn init(
     registers: &Rc<RefCell<Registers>>,
     task_collection: &Rc<RefCell<task::Collection>>,
 ) -> (
-    Xhc,
     event::Ring,
     Rc<RefCell<DeviceContextBaseAddressArray>>,
     Rc<LocalMutex<Runner>>,
@@ -67,7 +66,6 @@ fn init(
     xhc.run();
 
     (
-        xhc,
         event_ring,
         dcbaa,
         command_runner,

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -24,9 +24,9 @@ use {
 pub async fn task(task_collection: Rc<RefCell<task::Collection>>) {
     let registers = Rc::new(RefCell::new(iter_devices().next().unwrap()));
     let (event_ring, dcbaa, runner, command_completion_receiver) =
-        init(&registers, &task_collection.clone());
+        init(&registers, &task_collection);
 
-    port::spawn_tasks(&runner, &dcbaa, &registers, &task_collection.clone());
+    port::spawn_tasks(&runner, &dcbaa, &registers, &task_collection);
 
     task_collection
         .borrow_mut()

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -36,6 +36,8 @@ pub async fn task(task_collection: Rc<RefCell<task::Collection>>) {
         )));
 }
 
+// FIXME
+#[allow(clippy::type_complexity)]
 fn init(
     registers: &Rc<RefCell<Registers>>,
     task_collection: &Rc<RefCell<task::Collection>>,

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -36,10 +36,10 @@ async fn task(mut port: Port, command_runner: Rc<LocalMutex<Runner>>) {
 // FIXME: Resolve this.
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_tasks(
-    command_runner: Rc<LocalMutex<Runner>>,
-    dcbaa: Rc<RefCell<DeviceContextBaseAddressArray>>,
-    registers: Rc<RefCell<Registers>>,
-    task_collection: Rc<RefCell<task::Collection>>,
+    command_runner: &Rc<LocalMutex<Runner>>,
+    dcbaa: &Rc<RefCell<DeviceContextBaseAddressArray>>,
+    registers: &Rc<RefCell<Registers>>,
+    task_collection: &Rc<RefCell<task::Collection>>,
 ) {
     for i in 0..num_of_ports(&registers) {
         let port = Port::new(registers.clone(), dcbaa.clone(), i);

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -33,6 +33,8 @@ async fn task(mut port: Port, command_runner: Rc<LocalMutex<Runner>>) {
     port.register_to_dcbaa(slot_id.into());
 }
 
+// FIXME: Resolve this.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_tasks(
     command_runner: Rc<LocalMutex<Runner>>,
     dcbaa: Rc<RefCell<DeviceContextBaseAddressArray>>,


### PR DESCRIPTION
- chore: add `output_device_context` as a member
- chore: change the type to `PhysAddr`
- chore: implement `Index` and `IndexMut` for DCBAA
- chore: register the address to DCBAA
- refactor: remove `TaskSpawner`
- chore: allow too many arguments

bors r+
