### PR TITLE
fix: mark `Accessor::new(_slice)?` as unsafe

### DIFF
--- a/kernel/src/device/pci/ahci/mod.rs
+++ b/kernel/src/device/pci/ahci/mod.rs
@@ -35,7 +35,9 @@ fn init() -> Option<(Rc<RefCell<Registers>>, Ahc)> {
 
 fn fetch_registers() -> Option<Registers> {
     let abar = AchiBaseAddr::new()?;
-    Some(Registers::new(abar))
+
+    // Safety: This operation is safe because `abar` is generated from the 5th BAR.
+    Some(unsafe { Registers::new(abar) })
 }
 
 #[derive(Copy, Clone)]

--- a/kernel/src/device/pci/ahci/registers/generic.rs
+++ b/kernel/src/device/pci/ahci/registers/generic.rs
@@ -11,7 +11,9 @@ pub struct Generic {
     pub bohc: Accessor<BiosOsHandoffControlAndStatus>,
 }
 impl Generic {
-    pub fn new(abar: AchiBaseAddr) -> Self {
+    /// Safety: This method is unsafe because if `abar` is not the valid AHCI base address, this
+    /// method can violate memory safety.
+    pub unsafe fn new(abar: AchiBaseAddr) -> Self {
         let cap = Accessor::new(abar.into(), Bytes::new(0x00));
         let ghc = Accessor::new(abar.into(), Bytes::new(0x04));
         let pi = Accessor::new(abar.into(), Bytes::new(0x0c));

--- a/kernel/src/device/pci/ahci/registers/mod.rs
+++ b/kernel/src/device/pci/ahci/registers/mod.rs
@@ -10,14 +10,21 @@ pub struct Registers {
     pub port_regs: Vec<Option<port::Registers>>,
 }
 impl Registers {
-    pub fn new(abar: AchiBaseAddr) -> Self {
+    /// Safety: This method is unsafe because if `abar` is not the valid AHCI base address, it can
+    /// violate memory safety.
+    pub unsafe fn new(abar: AchiBaseAddr) -> Self {
         let generic = Generic::new(abar);
         let port_regs = Self::collect_port_regs(abar, &generic);
 
         Self { generic, port_regs }
     }
 
-    fn collect_port_regs(abar: AchiBaseAddr, generic: &Generic) -> Vec<Option<port::Registers>> {
+    /// Safety: This method is unsafe because if `abar` is not the valid AHCI base address, it can
+    /// violate memory safety.
+    unsafe fn collect_port_regs(
+        abar: AchiBaseAddr,
+        generic: &Generic,
+    ) -> Vec<Option<port::Registers>> {
         (0..32)
             .map(|i| port::Registers::new(abar, i, generic))
             .collect()

--- a/kernel/src/device/pci/ahci/registers/port.rs
+++ b/kernel/src/device/pci/ahci/registers/port.rs
@@ -20,7 +20,9 @@ pub struct Registers {
     pub ci: Accessor<PortxCommandIssue>,
 }
 impl Registers {
-    pub fn new(abar: AchiBaseAddr, port_index: usize, generic: &Generic) -> Option<Self> {
+    /// Safety: This method is unsafe because if `abar` is not a valid AHCI base address, it can
+    /// violate memory safety.
+    pub unsafe fn new(abar: AchiBaseAddr, port_index: usize, generic: &Generic) -> Option<Self> {
         if Self::exist(port_index, generic) {
             Some(Self::fetch(abar, port_index))
         } else {
@@ -32,7 +34,9 @@ impl Registers {
         generic.pi.read().0 & (1 << port_index) != 0
     }
 
-    fn fetch(abar: AchiBaseAddr, port_index: usize) -> Self {
+    /// Safety: This method is unsafe because if `abar` is not a valid AHCI base address, it can
+    /// violate memory safety.
+    unsafe fn fetch(abar: AchiBaseAddr, port_index: usize) -> Self {
         let base_addr = Self::base_addr_to_registers(abar, port_index);
 
         macro_rules! new_accessor {

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -78,7 +78,9 @@ fn init(
 pub fn iter_devices() -> impl Iterator<Item = Registers> {
     super::iter_devices().filter_map(|device| {
         if device.is_xhci() {
-            Some(Registers::new(device.base_address(bar::Index::new(0))))
+            // Safety: This operation is safe because MMIO base address is generated from the 0th
+            // BAR.
+            Some(unsafe { Registers::new(device.base_address(bar::Index::new(0))) })
         } else {
             None
         }

--- a/kernel/src/device/pci/xhci/register/hc_capability.rs
+++ b/kernel/src/device/pci/xhci/register/hc_capability.rs
@@ -12,7 +12,9 @@ pub struct HCCapabilityRegisters {
 }
 
 impl HCCapabilityRegisters {
-    pub fn new(mmio_base: PhysAddr) -> Self {
+    /// Safety: This method is unsafe because if `mmio_base` is not the valid MMIO base address, it
+    /// can violate memory safety.
+    pub unsafe fn new(mmio_base: PhysAddr) -> Self {
         let cap_length = Accessor::new(mmio_base, Bytes::new(0));
         let hcs_params_1 = Accessor::new(mmio_base, Bytes::new(0x04));
         let hcs_params_2 = Accessor::new(mmio_base, Bytes::new(0x08));

--- a/kernel/src/device/pci/xhci/register/hc_operational.rs
+++ b/kernel/src/device/pci/xhci/register/hc_operational.rs
@@ -15,7 +15,9 @@ pub struct HCOperational {
 }
 
 impl HCOperational {
-    pub fn new(mmio_base: PhysAddr, capabilities: &HCCapabilityRegisters) -> Self {
+    /// Safety: This method is unsafe because if `mmio_base` is not a valid MMIO base address, it
+    /// can violate memory safety.
+    pub unsafe fn new(mmio_base: PhysAddr, capabilities: &HCCapabilityRegisters) -> Self {
         let operational_base = mmio_base + capabilities.cap_length.read().get();
 
         let usb_cmd = Accessor::new(operational_base, Bytes::new(0x00));

--- a/kernel/src/device/pci/xhci/register/mod.rs
+++ b/kernel/src/device/pci/xhci/register/mod.rs
@@ -20,7 +20,9 @@ pub struct Registers {
     pub doorbell_array: doorbell::Array,
 }
 impl Registers {
-    pub fn new(mmio_base: PhysAddr) -> Self {
+    /// Safety: This method is unsafe because if `mmio_base` is not the valid MMIO base address,
+    /// it can violate memory safety.
+    pub unsafe fn new(mmio_base: PhysAddr) -> Self {
         let hc_capability_registers = HCCapabilityRegisters::new(mmio_base);
         let usb_legacy_support_capability =
             UsbLegacySupportCapability::new(mmio_base, &hc_capability_registers);

--- a/kernel/src/device/pci/xhci/register/runtime_base_registers.rs
+++ b/kernel/src/device/pci/xhci/register/runtime_base_registers.rs
@@ -8,7 +8,9 @@ pub struct RuntimeBaseRegisters {
     pub erd_p: Accessor<EventRingDequeuePointerRegister>,
 }
 impl<'a> RuntimeBaseRegisters {
-    pub fn new(mmio_base: PhysAddr, runtime_register_space_offset: usize) -> Self {
+    /// Safety: This method is unsafe because if `mmio_base` is not a valid address, or
+    /// `runtime_register_space_offset` is not a valid value, it can violate memory safety.
+    pub unsafe fn new(mmio_base: PhysAddr, runtime_register_space_offset: usize) -> Self {
         let runtime_base = mmio_base + runtime_register_space_offset;
         let erst_sz = Accessor::new(runtime_base, Bytes::new(0x28));
         let erst_ba = Accessor::new(runtime_base, Bytes::new(0x30));

--- a/kernel/src/device/pci/xhci/register/usb_legacy_support_capability.rs
+++ b/kernel/src/device/pci/xhci/register/usb_legacy_support_capability.rs
@@ -14,7 +14,9 @@ pub struct UsbLegacySupportCapability {
 }
 
 impl UsbLegacySupportCapability {
-    pub fn new(
+    /// Safety: This method is unsafe because if `mmio_base` is not a valid MMIO base address, it
+    /// can violate memory safety.
+    pub unsafe fn new(
         mmio_base: PhysAddr,
         hc_capability_registers: &HCCapabilityRegisters,
     ) -> Option<Self> {

--- a/kernel/src/mem/accessor.rs
+++ b/kernel/src/mem/accessor.rs
@@ -19,7 +19,9 @@ pub struct Accessor<T: ?Sized> {
     _marker: PhantomData<T>,
 }
 impl<T> Accessor<T> {
-    pub fn new(phys_base: PhysAddr, offset: Bytes) -> Self {
+    /// Safety: This method is unsafe because it can create multiple mutable references to the same
+    /// object.
+    pub unsafe fn new(phys_base: PhysAddr, offset: Bytes) -> Self {
         let phys_base = phys_base + offset.as_usize();
         let virt = Self::map_pages(phys_base, Bytes::new(mem::size_of::<T>()));
 
@@ -49,6 +51,8 @@ impl<T> Accessor<T> {
 }
 
 impl<T> Accessor<[T]> {
+    /// Safety: This method is unsafe because it can create multiple mutable references to the same
+    /// object.
     pub fn new_slice(phys_base: PhysAddr, offset: Bytes, len: usize) -> Self {
         let phys_base = phys_base + offset.as_usize();
         let bytes = Bytes::new(mem::size_of::<T>() * len);


### PR DESCRIPTION
bors r+
