### PR TITLE
Prepare command lists

### DIFF
--- a/kernel/src/device/pci/ahci/port/command_list.rs
+++ b/kernel/src/device/pci/ahci/port/command_list.rs
@@ -25,13 +25,7 @@ impl CommandList {
     }
 }
 
-#[derive(Copy, Clone)]
-pub struct CommandHeader(CommandHeaderStructure<[u32; 8]>);
-impl CommandHeader {
-    fn null() -> Self {
-        Self(CommandHeaderStructure::null())
-    }
-}
+pub type CommandHeader = CommandHeaderStructure<[u32; 8]>;
 bitfield! {
     #[repr(transparent)]
     #[derive(Copy,Clone)]

--- a/kernel/src/device/pci/ahci/port/command_list.rs
+++ b/kernel/src/device/pci/ahci/port/command_list.rs
@@ -1,38 +1,97 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use {
-    super::Registers, crate::mem::allocator::page_box::PageBox, bitfield::bitfield,
-    core::convert::TryInto, x86_64::PhysAddr,
+    super::Registers, crate::mem::allocator::page_box::PageBox, alloc::vec::Vec,
+    bitfield::bitfield, core::convert::TryInto, x86_64::PhysAddr,
 };
 
-pub struct CommandList(PageBox<[CommandHeader]>);
+const NUM_OF_PRDT: usize = 8;
+
+pub struct CommandList {
+    headers: PageBox<[Header]>,
+    tables: Vec<PageBox<Table>>,
+}
 impl CommandList {
     pub fn new(registers: &Registers) -> Self {
-        Self(PageBox::new_slice(
-            CommandHeader::null(),
-            Self::num_of_command_slots_supported(registers)
-                .try_into()
-                .unwrap(),
-        ))
+        let headers = PageBox::new_slice(
+            Header::null(),
+            Self::num_of_command_slots_supported(registers),
+        );
+        let tables = Self::new_tables(registers);
+        let mut list = Self { headers, tables };
+        list.set_ptrs_of_headers();
+        list
     }
 
-    pub fn phys_addr(&self) -> PhysAddr {
-        self.0.phys_addr()
+    pub fn phys_addr_to_headers(&self) -> PhysAddr {
+        self.headers.phys_addr()
     }
 
-    fn num_of_command_slots_supported(registers: &Registers) -> u32 {
-        registers.generic.cap.read().num_of_command_slots()
+    fn new_tables(registers: &Registers) -> Vec<PageBox<Table>> {
+        let mut tables = Vec::new();
+        for _ in 0..Self::num_of_command_slots_supported(registers) {
+            tables.push(PageBox::new(Table::null()));
+        }
+        tables
+    }
+
+    fn set_ptrs_of_headers(&mut self) {
+        for header in self.headers.iter_mut() {
+            header.set_command_table_base_addr(self.tables[0].phys_addr());
+        }
+    }
+
+    fn num_of_command_slots_supported(registers: &Registers) -> usize {
+        registers
+            .generic
+            .cap
+            .read()
+            .num_of_command_slots()
+            .try_into()
+            .unwrap()
     }
 }
 
-pub type CommandHeader = CommandHeaderStructure<[u32; 8]>;
+pub type Header = CommandHeaderStructure<[u32; 8]>;
 bitfield! {
     #[repr(transparent)]
     #[derive(Copy,Clone)]
     pub struct CommandHeaderStructure([u32]);
     impl Debug;
+    u64, _, set_command_table_base_addr_as_u64: 64+31, 64;
 }
 impl CommandHeaderStructure<[u32; 8]> {
+    fn null() -> Self {
+        Self([0; 8])
+    }
+
+    fn set_command_table_base_addr(&mut self, addr: PhysAddr) {
+        assert!(addr.is_aligned(128_u64));
+        self.set_command_table_base_addr_as_u64(addr.as_u64());
+    }
+}
+
+pub struct Table {
+    rsvd: [u8; 0x80],
+    prdt: [PhysicalRegionDescriptorTable; NUM_OF_PRDT],
+}
+impl Table {
+    fn null() -> Self {
+        Self {
+            rsvd: [0; 0x80],
+            prdt: [PhysicalRegionDescriptorTable::null(); NUM_OF_PRDT],
+        }
+    }
+}
+
+pub type PhysicalRegionDescriptorTable = PhysicalRegionDescriptorTableStructure<[u32; 8]>;
+bitfield! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone)]
+    pub struct PhysicalRegionDescriptorTableStructure([u32]);
+    impl Debug;
+}
+impl PhysicalRegionDescriptorTable {
     fn null() -> Self {
         Self([0; 8])
     }

--- a/kernel/src/device/pci/ahci/port/mod.rs
+++ b/kernel/src/device/pci/ahci/port/mod.rs
@@ -104,7 +104,7 @@ impl Port {
     }
 
     fn register_command_list(&mut self) {
-        let addr = self.command_list.phys_addr();
+        let addr = self.command_list.phys_addr_to_headers();
         self.edit_port_rg(|rg| rg.clb.update(|b| b.set(addr)));
     }
 


### PR DESCRIPTION
- refactor: use `type` to define a new type
- chore: initialize command tables

bors r+
