### PR TITLE
Issue an address device TRB

### DIFF
--- a/kernel/src/device/pci/xhci/command_runner.rs
+++ b/kernel/src/device/pci/xhci/command_runner.rs
@@ -37,6 +37,20 @@ impl Runner {
         Ok(completion_trb.slot_id())
     }
 
+    pub async fn address_device(
+        &mut self,
+        addr_to_input_context: PhysAddr,
+        slot_id: u8,
+    ) -> Result<(), command::Error> {
+        let addr_to_trb = self
+            .ring
+            .borrow_mut()
+            .send_address_device(addr_to_input_context, slot_id)?;
+        self.register_to_receiver(addr_to_trb);
+        let completion_trb = self.get_trb(addr_to_trb).await;
+        Ok(())
+    }
+
     fn register_to_receiver(&mut self, addr_to_trb: PhysAddr) {
         self.receiver
             .borrow_mut()

--- a/kernel/src/device/pci/xhci/context.rs
+++ b/kernel/src/device/pci/xhci/context.rs
@@ -5,13 +5,13 @@ use x86_64::PhysAddr;
 
 #[repr(C)]
 pub struct Input {
-    pub input_control: InputControl,
+    pub control: InputControl,
     pub device: Device,
 }
 impl Input {
     pub fn null() -> Self {
         Self {
-            input_control: InputControl::null(),
+            control: InputControl::null(),
             device: Device::null(),
         }
     }

--- a/kernel/src/device/pci/xhci/context.rs
+++ b/kernel/src/device/pci/xhci/context.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use bitfield::bitfield;
+use {bitfield::bitfield, x86_64::PhysAddr};
 
 #[repr(C, packed)]
 pub struct Input {
@@ -68,13 +68,18 @@ bitfield! {
     impl Debug;
     pub u32, _, set_endpoint_type_as_u32: 32+5, 32+3;
     pub u32, _, set_max_packet_size: 32+31, 32+16;
-    pub u64, _, set_dequeue_ptr: 96+31, 64;
+    u64, _, set_dequeue_ptr_as_u64: 96+31, 64;
     pub _, set_dequeue_cycle_state: 64;
     pub u32, _, set_error_count: 32+2, 32+1;
 }
 impl EndpointStructure<[u32; 8]> {
     pub fn set_endpoint_type(&mut self, ty: EndpointType) {
         self.set_endpoint_type_as_u32(ty as u32);
+    }
+
+    pub fn set_dequeue_ptr(&mut self, addr: PhysAddr) {
+        assert!(addr.is_aligned(16_u64));
+        self.set_dequeue_ptr_as_u64(addr.as_u64());
     }
 
     fn null() -> Self {

--- a/kernel/src/device/pci/xhci/context.rs
+++ b/kernel/src/device/pci/xhci/context.rs
@@ -5,6 +5,7 @@ use {
     core::ops::{Deref, DerefMut},
 };
 
+#[repr(C, packed)]
 pub struct Input {
     pub input_control: InputControl,
     pub device: Device,
@@ -31,6 +32,7 @@ impl InputControl {
     }
 }
 
+#[repr(C, packed)]
 pub struct Device {
     pub slot: Slot,
     pub ep_0: Endpoint,
@@ -46,6 +48,7 @@ impl Device {
     }
 }
 
+#[repr(C, packed)]
 #[derive(Copy, Clone)]
 pub struct EndpointOutIn {
     out: Endpoint,
@@ -93,6 +96,7 @@ pub enum EndpointType {
     Control = 4,
 }
 
+#[repr(transparent)]
 pub struct Slot(pub SlotStructure<[u32; 8]>);
 impl Slot {
     pub fn null() -> Self {

--- a/kernel/src/device/pci/xhci/context.rs
+++ b/kernel/src/device/pci/xhci/context.rs
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use {
-    bitfield::bitfield,
-    core::ops::{Deref, DerefMut},
-};
+use bitfield::bitfield;
 
 #[repr(C, packed)]
 pub struct Input {

--- a/kernel/src/device/pci/xhci/context.rs
+++ b/kernel/src/device/pci/xhci/context.rs
@@ -3,7 +3,7 @@
 use bitfield::bitfield;
 use x86_64::PhysAddr;
 
-#[repr(C, packed)]
+#[repr(C)]
 pub struct Input {
     pub input_control: InputControl,
     pub device: Device,
@@ -30,7 +30,7 @@ impl InputControl {
     }
 }
 
-#[repr(C, packed)]
+#[repr(C)]
 pub struct Device {
     pub slot: Slot,
     pub ep_0: Endpoint,
@@ -46,7 +46,7 @@ impl Device {
     }
 }
 
-#[repr(C, packed)]
+#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct EndpointOutIn {
     out: Endpoint,

--- a/kernel/src/device/pci/xhci/context.rs
+++ b/kernel/src/device/pci/xhci/context.rs
@@ -73,7 +73,7 @@ bitfield! {
     pub _, set_dequeue_cycle_state: 64;
     pub u32, _, set_error_count: 32+2, 32+1;
 }
-impl EndpointStructure<[u32; 8]> {
+impl Endpoint {
     pub fn set_endpoint_type(&mut self, ty: EndpointType) {
         self.set_endpoint_type_as_u32(ty as u32);
     }
@@ -100,8 +100,8 @@ bitfield! {
     pub u8, _, set_context_entries: 31, 27;
     pub u8, _, set_root_hub_port_number: 32+23, 32+16;
 }
-impl<const N: usize> SlotStructure<[u32; N]> {
+impl Slot {
     fn null() -> Self {
-        Self([0; N])
+        Self([0; 8])
     }
 }

--- a/kernel/src/device/pci/xhci/context.rs
+++ b/kernel/src/device/pci/xhci/context.rs
@@ -63,14 +63,7 @@ impl EndpointOutIn {
     }
 }
 
-#[repr(transparent)]
-#[derive(Copy, Clone)]
-pub struct Endpoint(pub EndpointStructure<[u32; 8]>);
-impl Endpoint {
-    fn null() -> Self {
-        Self(EndpointStructure::null())
-    }
-}
+pub type Endpoint = EndpointStructure<[u32; 8]>;
 bitfield! {
     #[repr(transparent)]
     #[derive(Copy,Clone)]
@@ -96,13 +89,7 @@ pub enum EndpointType {
     Control = 4,
 }
 
-#[repr(transparent)]
-pub struct Slot(pub SlotStructure<[u32; 8]>);
-impl Slot {
-    pub fn null() -> Self {
-        Self(SlotStructure::null())
-    }
-}
+pub type Slot = SlotStructure<[u32; 8]>;
 bitfield! {
     #[repr(transparent)]
     pub struct SlotStructure([u32]);

--- a/kernel/src/device/pci/xhci/context.rs
+++ b/kernel/src/device/pci/xhci/context.rs
@@ -46,6 +46,20 @@ impl Device {
     }
 }
 
+pub type Slot = SlotStructure<[u32; 8]>;
+bitfield! {
+    #[repr(transparent)]
+    pub struct SlotStructure([u32]);
+
+    pub u8, _, set_context_entries: 31, 27;
+    pub u8, _, set_root_hub_port_number: 32+23, 32+16;
+}
+impl Slot {
+    fn null() -> Self {
+        Self([0; 8])
+    }
+}
+
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct EndpointOutIn {
@@ -90,18 +104,4 @@ impl Endpoint {
 
 pub enum EndpointType {
     Control = 4,
-}
-
-pub type Slot = SlotStructure<[u32; 8]>;
-bitfield! {
-    #[repr(transparent)]
-    pub struct SlotStructure([u32]);
-
-    pub u8, _, set_context_entries: 31, 27;
-    pub u8, _, set_root_hub_port_number: 32+23, 32+16;
-}
-impl Slot {
-    fn null() -> Self {
-        Self([0; 8])
-    }
 }

--- a/kernel/src/device/pci/xhci/context.rs
+++ b/kernel/src/device/pci/xhci/context.rs
@@ -97,6 +97,7 @@ bitfield! {
     pub struct SlotStructure([u32]);
 
     pub u8, _, set_context_entries: 31, 27;
+    pub u8, _, set_root_hub_port_number: 32+23, 32+16;
 }
 impl<const N: usize> SlotStructure<[u32; N]> {
     fn null() -> Self {

--- a/kernel/src/device/pci/xhci/context.rs
+++ b/kernel/src/device/pci/xhci/context.rs
@@ -32,7 +32,7 @@ impl InputControl {
 }
 
 pub struct Device {
-    slot: Slot,
+    pub slot: Slot,
     pub ep_0: Endpoint,
     ep_inout: [EndpointOutIn; 15],
 }
@@ -93,21 +93,10 @@ pub enum EndpointType {
     Control = 4,
 }
 
-pub struct Slot(SlotStructure<[u32; 8]>);
+pub struct Slot(pub SlotStructure<[u32; 8]>);
 impl Slot {
     pub fn null() -> Self {
         Self(SlotStructure::null())
-    }
-}
-impl Deref for Slot {
-    type Target = SlotStructure<[u32; 8]>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl DerefMut for Slot {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 bitfield! {

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -16,17 +16,12 @@ use core::{cell::RefCell, convert::TryInto};
 use futures_intrusive::sync::LocalMutex;
 use x86_64::PhysAddr;
 
-async fn task(mut port: Port, command_runner: Rc<LocalMutex<Runner>>) {
+async fn task(mut port: Port, runner: Rc<LocalMutex<Runner>>) {
     port.reset_if_connected();
 
-    let slot_id = command_runner
-        .lock()
-        .await
-        .enable_device_slot()
-        .await
-        .unwrap();
+    let slot_id = runner.lock().await.enable_device_slot().await.unwrap();
 
-    port.init_device_slot(slot_id, command_runner).await;
+    port.init_device_slot(slot_id, runner).await;
 }
 
 // FIXME: Resolve this.

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -113,7 +113,7 @@ impl Port {
     }
 
     fn init_input_context(&mut self) {
-        let input_control = &mut self.input_context.input_control;
+        let input_control = &mut self.input_context.control;
         input_control.set_aflag(0);
         input_control.set_aflag(1);
     }

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -35,7 +35,7 @@ async fn task(mut port: Port, command_runner: Rc<LocalMutex<Runner>>) {
     command_runner
         .lock()
         .await
-        .address_device(port.input_context_addr(), slot_id)
+        .address_device(port.addr_to_input_context(), slot_id)
         .await
         .unwrap();
 }
@@ -133,7 +133,7 @@ impl Port {
         ep_0.set_error_count(3);
     }
 
-    fn input_context_addr(&self) -> PhysAddr {
+    fn addr_to_input_context(&self) -> PhysAddr {
         self.input_context.phys_addr()
     }
 

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -113,24 +113,24 @@ impl Port {
     }
 
     fn init_input_context(&mut self) {
-        self.input_context.input_control.set_aflag(0);
-        self.input_context.input_control.set_aflag(1);
+        let input_control = &mut self.input_context.input_control;
+        input_control.set_aflag(0);
+        input_control.set_aflag(1);
     }
 
     fn init_input_slot_context(&mut self) {
-        self.input_context.device.slot.set_context_entries(1);
-        self.input_context
-            .device
-            .slot
-            .set_root_hub_port_number(self.index.try_into().unwrap());
+        let slot = &mut self.input_context.device.slot;
+        slot.set_context_entries(1);
+        slot.set_root_hub_port_number(self.index.try_into().unwrap());
     }
 
     fn init_input_default_control_endpoint0_context(&mut self) {
         let ep_0 = &mut self.input_context.device.ep_0;
         ep_0.set_endpoint_type(EndpointType::Control);
-        compile_error!("Get the maximum packet size!");
+        // FIXME
+        ep_0.set_max_packet_size(64);
         ep_0.set_dequeue_ptr(self.transfer_ring.phys_addr());
-        ep_0.set_dequeue_cycle_state(false);
+        ep_0.set_dequeue_cycle_state(true);
         ep_0.set_error_count(3);
     }
 

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -120,11 +120,11 @@ impl Port {
     }
 
     fn init_input_slot_context(&mut self) {
-        self.input_context.device.slot.0.set_context_entries(1);
+        self.input_context.device.slot.set_context_entries(1);
     }
 
     fn init_input_default_control_endpoint0_context(&mut self) {
-        let ep_0 = &mut self.input_context.device.ep_0.0;
+        let ep_0 = &mut self.input_context.device.ep_0;
         ep_0.set_endpoint_type(EndpointType::Control);
         ep_0.set_dequeue_ptr(self.transfer_ring.phys_addr().as_u64());
         ep_0.set_dequeue_cycle_state(false);

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -26,16 +26,7 @@ async fn task(mut port: Port, command_runner: Rc<LocalMutex<Runner>>) {
         .await
         .unwrap();
 
-    port.init_input_context();
-    port.init_input_slot_context();
-    port.init_input_default_control_endpoint0_context();
-    port.register_to_dcbaa(slot_id.into());
-    command_runner
-        .lock()
-        .await
-        .address_device(port.addr_to_input_context(), slot_id)
-        .await
-        .unwrap();
+    port.init_device_slot(slot_id, command_runner).await;
 }
 
 // FIXME: Resolve this.
@@ -110,6 +101,20 @@ impl Port {
             let port_rg = self.read_port_rg();
             !port_rg.port_sc.port_reset_changed()
         } {}
+    }
+
+    async fn init_device_slot(&mut self, slot_id: u8, runner: Rc<LocalMutex<Runner>>) {
+        self.init_input_context();
+        self.init_input_slot_context();
+        self.init_input_default_control_endpoint0_context();
+        self.register_to_dcbaa(slot_id.into());
+
+        runner
+            .lock()
+            .await
+            .address_device(self.addr_to_input_context(), slot_id)
+            .await
+            .unwrap();
     }
 
     fn init_input_context(&mut self) {

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -67,7 +67,6 @@ pub struct Port {
     registers: Rc<RefCell<Registers>>,
     index: usize,
     input_context: PageBox<context::Input>,
-    input_slot_context: PageBox<context::Slot>,
     output_device_context: PageBox<context::Device>,
     transfer_ring: transfer::Ring,
     dcbaa: Rc<RefCell<DeviceContextBaseAddressArray>>,
@@ -88,7 +87,6 @@ impl Port {
             registers: registers.clone(),
             index,
             input_context: PageBox::new(context::Input::null()),
-            input_slot_context: PageBox::new(context::Slot::null()),
             output_device_context: PageBox::new(context::Device::null()),
             dcbaa,
             transfer_ring: transfer::Ring::new(registers),
@@ -122,7 +120,7 @@ impl Port {
     }
 
     fn init_input_slot_context(&mut self) {
-        self.input_slot_context.set_context_entries(1);
+        self.input_context.device.slot.0.set_context_entries(1);
     }
 
     fn init_input_default_control_endpoint0_context(&mut self) {

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -13,7 +13,7 @@ use {
         multitask::task::{self, Task},
     },
     alloc::rc::Rc,
-    core::cell::RefCell,
+    core::{cell::RefCell, convert::TryInto},
     futures_intrusive::sync::LocalMutex,
     x86_64::PhysAddr,
 };
@@ -121,6 +121,10 @@ impl Port {
 
     fn init_input_slot_context(&mut self) {
         self.input_context.device.slot.set_context_entries(1);
+        self.input_context
+            .device
+            .slot
+            .set_root_hub_port_number(self.index.try_into().unwrap());
     }
 
     fn init_input_default_control_endpoint0_context(&mut self) {

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -50,7 +50,7 @@ fn num_of_ports(registers: &Rc<RefCell<Registers>>) -> usize {
 pub struct Port {
     registers: Rc<RefCell<Registers>>,
     index: usize,
-    input_context: PageBox<context::Input>,
+    input_context: PageBox<context::Input>, // FIXME: Support 64-bit Input Control Context. See the note of xHCI dev manual 6.2.5.1.
     output_device_context: PageBox<context::Device>,
     transfer_ring: transfer::Ring,
     dcbaa: Rc<RefCell<DeviceContextBaseAddressArray>>,

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -126,7 +126,8 @@ impl Port {
     fn init_input_default_control_endpoint0_context(&mut self) {
         let ep_0 = &mut self.input_context.device.ep_0;
         ep_0.set_endpoint_type(EndpointType::Control);
-        ep_0.set_dequeue_ptr(self.transfer_ring.phys_addr().as_u64());
+        compile_error!("Get the maximum packet size!");
+        ep_0.set_dequeue_ptr(self.transfer_ring.phys_addr());
         ep_0.set_dequeue_cycle_state(false);
         ep_0.set_error_count(3);
     }

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -33,7 +33,7 @@ pub fn spawn_tasks(
     task_collection: &Rc<RefCell<task::Collection>>,
 ) {
     for i in 0..num_of_ports(&registers) {
-        let port = Port::new(registers.clone(), dcbaa.clone(), i);
+        let port = Port::new(registers.clone(), dcbaa.clone(), i + 1);
         if port.connected() {
             task_collection
                 .borrow_mut()
@@ -88,7 +88,7 @@ impl Port {
 
     fn start_resetting(&mut self) {
         let port_rg = &mut self.registers.borrow_mut().hc_operational.port_registers;
-        port_rg.update(self.index, |rg| rg.port_sc.set_port_reset(true))
+        port_rg.update(self.index - 1, |rg| rg.port_sc.set_port_reset(true))
     }
 
     fn wait_until_reset_completed(&self) {
@@ -144,6 +144,6 @@ impl Port {
 
     fn read_port_rg(&self) -> PortRegisters {
         let port_rg = &self.registers.borrow().hc_operational.port_registers;
-        port_rg.read(self.index)
+        port_rg.read(self.index - 1)
     }
 }

--- a/kernel/src/device/pci/xhci/register/hc_capability.rs
+++ b/kernel/src/device/pci/xhci/register/hc_capability.rs
@@ -65,6 +65,7 @@ impl StructuralParameters2 {
 bitfield! {
     #[repr(transparent)]
     pub struct HCCapabilityParameters1(u32);
+    pub csz, _: 2;
     pub xhci_extended_capabilities_pointer,_: 31,16;
 }
 

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -38,6 +38,18 @@ impl<'a> Ring {
         Ok(phys_addr_to_trb)
     }
 
+    pub fn send_address_device(
+        &mut self,
+        addr_to_input_context: PhysAddr,
+        slot_id: u8,
+    ) -> Result<PhysAddr, Error> {
+        let address_device =
+            Trb::new_address_device(self.cycle_bit, addr_to_input_context, slot_id);
+        let phys_addr_to_trb = self.enqueue(address_device)?;
+        self.notify_command_is_sent();
+        Ok(phys_addr_to_trb)
+    }
+
     fn notify_command_is_sent(&mut self) {
         let doorbell_array = &mut self.registers.borrow_mut().doorbell_array;
         doorbell_array.update(0, |reg| *reg = 0)

--- a/kernel/src/device/pci/xhci/ring/raw.rs
+++ b/kernel/src/device/pci/xhci/ring/raw.rs
@@ -60,6 +60,7 @@ impl From<trb::Trb> for Trb {
             trb::Trb::Link(link) => Self(link.0),
             trb::Trb::PortStatusChange(change) => Self(change.0),
             trb::Trb::EnableSlot(enable) => Self(enable.0),
+            trb::Trb::AddressDevice(address) => Self(address.0),
         }
     }
 }

--- a/kernel/src/device/pci/xhci/ring/trb.rs
+++ b/kernel/src/device/pci/xhci/ring/trb.rs
@@ -186,7 +186,7 @@ impl AddressDevice {
     pub fn new(cycle_bit: CycleBit, addr_to_input_context: PhysAddr, slot_id: u8) -> Self {
         let mut trb = Self(0);
 
-        assert!(addr_to_input_context.as_u64().trailing_zeros() >= 4);
+        assert!(addr_to_input_context.is_aligned(16_u64));
         trb.set_input_context_ptr_as_u64(addr_to_input_context.as_u64());
         trb.set_cycle_bit(cycle_bit.into());
         trb.set_trb_type(Self::ID);


### PR DESCRIPTION
- chore: send an address device trb
- refactor: use `is_aligned` method
- refactor: rename to `addr_to_input_context`
- fix: wrong initialization
- chore: apply `repr`
- refactor: use `type` to wrap the internal structures
- refactor: remove unused imports
- chore: take an `PhysAddr`, not `u64`
- fix: set root hub port number
- refactor: clean codes
- refactor: define `init_device_slot`
- refactor: rename to `runner`
- refactor: rename to `control`
- refactor: use aliased types
- chore: add a message
- chore: add a method
- refactor: reorder structs
- fix: 1-indexed

bors r+
