### PR TITLE
Refactor the code of command ring

### DIFF
--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -95,8 +95,7 @@ impl<'a> Ring {
         }
 
         self.append_link_trb();
-        self.enqueue_ptr = 0;
-        self.cycle_bit.toggle();
+        self.move_enqueue_ptr_to_the_beginning();
     }
 
     fn len(&self) -> usize {
@@ -105,6 +104,11 @@ impl<'a> Ring {
 
     fn append_link_trb(&mut self) {
         self.raw[self.enqueue_ptr] = Trb::new_link(self.phys_addr(), self.cycle_bit).into();
+    }
+
+    fn move_enqueue_ptr_to_the_beginning(&mut self) {
+        self.enqueue_ptr = 0;
+        self.cycle_bit.toggle();
     }
 }
 

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -75,17 +75,17 @@ impl<'a> Ring {
         }
     }
 
+    fn full(&self) -> bool {
+        let raw = self.raw[self.enqueue_ptr];
+        raw.cycle_bit() == self.cycle_bit
+    }
+
     fn enqueue(&mut self, trb: Trb) -> PhysAddr {
         self.raw[self.enqueue_ptr] = trb.into();
 
         let addr_to_trb = self.addr_to_enqueue_ptr();
         self.increment_enqueue_ptr();
         addr_to_trb
-    }
-
-    fn full(&self) -> bool {
-        let raw = self.raw[self.enqueue_ptr];
-        raw.cycle_bit() == self.cycle_bit
     }
 
     fn addr_to_enqueue_ptr(&self) -> PhysAddr {

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -74,18 +74,18 @@ impl<'a> Ring {
 
         self.raw[self.enqueue_ptr] = trb.into();
 
-        let phys_addr_to_trb = self.phys_addr_to_enqueue_ptr();
+        let addr_to_trb = self.addr_to_enqueue_ptr();
 
         self.enqueue_ptr += 1;
         if self.enqueue_ptr < self.len() - 1 {
-            return Ok(phys_addr_to_trb);
+            return Ok(addr_to_trb);
         }
 
         self.raw[self.enqueue_ptr] = Trb::new_link(self.phys_addr(), self.cycle_bit).into();
         self.enqueue_ptr = 0;
         self.cycle_bit.toggle();
 
-        Ok(phys_addr_to_trb)
+        Ok(addr_to_trb)
     }
 
     fn full(&self) -> bool {
@@ -93,7 +93,7 @@ impl<'a> Ring {
         raw.cycle_bit() == self.cycle_bit
     }
 
-    fn phys_addr_to_enqueue_ptr(&self) -> PhysAddr {
+    fn addr_to_enqueue_ptr(&self) -> PhysAddr {
         self.phys_addr() + Trb::SIZE.as_usize() * self.enqueue_ptr
     }
 

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -88,13 +88,13 @@ impl<'a> Ring {
         Ok(phys_addr_to_trb)
     }
 
-    fn phys_addr_to_enqueue_ptr(&self) -> PhysAddr {
-        self.phys_addr() + Trb::SIZE.as_usize() * self.enqueue_ptr
-    }
-
     fn full(&self) -> bool {
         let raw = self.raw[self.enqueue_ptr];
         raw.cycle_bit() == self.cycle_bit
+    }
+
+    fn phys_addr_to_enqueue_ptr(&self) -> PhysAddr {
+        self.phys_addr() + Trb::SIZE.as_usize() * self.enqueue_ptr
     }
 
     fn len(&self) -> usize {

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -68,7 +68,7 @@ impl<'a> Ring {
     }
 
     fn enqueue(&mut self, trb: Trb) -> Result<PhysAddr, Error> {
-        if !self.enqueueable() {
+        if self.full() {
             return Err(Error::QueueIsFull);
         }
 
@@ -92,9 +92,9 @@ impl<'a> Ring {
         self.phys_addr() + Trb::SIZE.as_usize() * self.enqueue_ptr
     }
 
-    fn enqueueable(&self) -> bool {
+    fn full(&self) -> bool {
         let raw = self.raw[self.enqueue_ptr];
-        raw.cycle_bit() != self.cycle_bit
+        raw.cycle_bit() == self.cycle_bit
     }
 
     fn len(&self) -> usize {

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -94,13 +94,17 @@ impl<'a> Ring {
             return;
         }
 
-        self.raw[self.enqueue_ptr] = Trb::new_link(self.phys_addr(), self.cycle_bit).into();
+        self.append_link_trb();
         self.enqueue_ptr = 0;
         self.cycle_bit.toggle();
     }
 
     fn len(&self) -> usize {
         self.raw.len()
+    }
+
+    fn append_link_trb(&mut self) {
+        self.raw[self.enqueue_ptr] = Trb::new_link(self.phys_addr(), self.cycle_bit).into();
     }
 }
 

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -81,11 +81,14 @@ impl<'a> Ring {
     }
 
     fn enqueue(&mut self, trb: Trb) -> PhysAddr {
-        self.raw[self.enqueue_ptr] = trb.into();
-
+        self.write_trb_on_memory(trb);
         let addr_to_trb = self.addr_to_enqueue_ptr();
         self.increment_enqueue_ptr();
         addr_to_trb
+    }
+
+    fn write_trb_on_memory(&mut self, trb: Trb) {
+        self.raw[self.enqueue_ptr] = trb.into();
     }
 
     fn addr_to_enqueue_ptr(&self) -> PhysAddr {

--- a/kernel/src/device/pci/xhci/ring/command.rs
+++ b/kernel/src/device/pci/xhci/ring/command.rs
@@ -75,16 +75,7 @@ impl<'a> Ring {
         self.raw[self.enqueue_ptr] = trb.into();
 
         let addr_to_trb = self.addr_to_enqueue_ptr();
-
-        self.enqueue_ptr += 1;
-        if self.enqueue_ptr < self.len() - 1 {
-            return Ok(addr_to_trb);
-        }
-
-        self.raw[self.enqueue_ptr] = Trb::new_link(self.phys_addr(), self.cycle_bit).into();
-        self.enqueue_ptr = 0;
-        self.cycle_bit.toggle();
-
+        self.increment_enqueue_ptr();
         Ok(addr_to_trb)
     }
 
@@ -95,6 +86,17 @@ impl<'a> Ring {
 
     fn addr_to_enqueue_ptr(&self) -> PhysAddr {
         self.phys_addr() + Trb::SIZE.as_usize() * self.enqueue_ptr
+    }
+
+    fn increment_enqueue_ptr(&mut self) {
+        self.enqueue_ptr += 1;
+        if self.enqueue_ptr < self.len() - 1 {
+            return;
+        }
+
+        self.raw[self.enqueue_ptr] = Trb::new_link(self.phys_addr(), self.cycle_bit).into();
+        self.enqueue_ptr = 0;
+        self.cycle_bit.toggle();
     }
 
     fn len(&self) -> usize {


### PR DESCRIPTION
- refactor: rename to `full`
- refactor: reorder methods
- refactor: remove `phys_`
- refactor: define `increment_enqueue_ptr`
- refactor: define `append_link_trb`
- refactor: define `move_enqueue_ptr_to_the_beginning`
- refactor: rename `enqueue` to `try_enqueue`
- refactor: reorder methods
- refactor: define `write_trb_on_memory`

bors r+
