### PR TITLE
Refactor code of transfer ring

### DIFF
--- a/kernel/src/device/pci/xhci/ring/transfer.rs
+++ b/kernel/src/device/pci/xhci/ring/transfer.rs
@@ -29,15 +29,19 @@ impl Ring {
 
     fn try_enqueue(&mut self, trb: Trb) -> Result<PhysAddr, Error> {
         if self.full() {
-            return Err(Error::QueueIsFull);
+            Err(Error::QueueIsFull)
+        } else {
+            Ok(self.enqueue(trb))
         }
+    }
 
+    fn enqueue(&mut self, trb: Trb) -> PhysAddr {
         self.raw[self.enqueue_ptr] = trb.into();
 
         let addr_to_trb = self.addr_to_enqueue_ptr();
         self.increment_enqueue_ptr();
 
-        Ok(addr_to_trb)
+        addr_to_trb
     }
 
     fn full(&self) -> bool {

--- a/kernel/src/device/pci/xhci/ring/transfer.rs
+++ b/kernel/src/device/pci/xhci/ring/transfer.rs
@@ -41,12 +41,15 @@ impl Ring {
     }
 
     fn enqueue(&mut self, trb: Trb) -> PhysAddr {
-        self.raw[self.enqueue_ptr] = trb.into();
-
+        self.write_trb_on_memory(trb);
         let addr_to_trb = self.addr_to_enqueue_ptr();
         self.increment_enqueue_ptr();
 
         addr_to_trb
+    }
+
+    fn write_trb_on_memory(&mut self, trb: Trb) {
+        self.raw[self.enqueue_ptr] = trb.into();
     }
 
     fn addr_to_enqueue_ptr(&self) -> PhysAddr {

--- a/kernel/src/device/pci/xhci/ring/transfer.rs
+++ b/kernel/src/device/pci/xhci/ring/transfer.rs
@@ -27,7 +27,7 @@ impl Ring {
         self.raw.phys_addr()
     }
 
-    fn enqueue(&mut self, trb: Trb) -> Result<PhysAddr, Error> {
+    fn try_enqueue(&mut self, trb: Trb) -> Result<PhysAddr, Error> {
         if self.full() {
             return Err(Error::QueueIsFull);
         }

--- a/kernel/src/device/pci/xhci/ring/transfer.rs
+++ b/kernel/src/device/pci/xhci/ring/transfer.rs
@@ -35,6 +35,11 @@ impl Ring {
         }
     }
 
+    fn full(&self) -> bool {
+        let raw = self.raw[self.enqueue_ptr];
+        raw.cycle_bit() == self.cycle_bit
+    }
+
     fn enqueue(&mut self, trb: Trb) -> PhysAddr {
         self.raw[self.enqueue_ptr] = trb.into();
 
@@ -42,11 +47,6 @@ impl Ring {
         self.increment_enqueue_ptr();
 
         addr_to_trb
-    }
-
-    fn full(&self) -> bool {
-        let raw = self.raw[self.enqueue_ptr];
-        raw.cycle_bit() == self.cycle_bit
     }
 
     fn addr_to_enqueue_ptr(&self) -> PhysAddr {


### PR DESCRIPTION
- refactor: rename `enqueue` to `try_enqueue`
- refactor: define `enqueue` method
- refactor: reorder methods
- refactor: define `write_trb_on_memory`

bors r+
