### PR TITLE
Revert "refactor: define `command::channel`"

### DIFF
--- a/kernel/src/device/pci/xhci/exchanger/command.rs
+++ b/kernel/src/device/pci/xhci/exchanger/command.rs
@@ -11,17 +11,8 @@ use core::{
     pin::Pin,
     task::{Context, Poll},
 };
-use futures_intrusive::sync::LocalMutex;
 use futures_util::task::AtomicWaker;
 use x86_64::PhysAddr;
-
-pub fn channel(
-    ring: Rc<RefCell<command::Ring>>,
-) -> (Rc<LocalMutex<Sender>>, Rc<RefCell<Receiver>>) {
-    let r = Rc::new(RefCell::new(Receiver::new()));
-    let s = Rc::new(LocalMutex::new(Sender::new(ring, r.clone()), false));
-    (s, r)
-}
 
 pub struct Sender {
     ring: Rc<RefCell<command::Ring>>,
@@ -29,6 +20,14 @@ pub struct Sender {
     waker: Rc<RefCell<AtomicWaker>>,
 }
 impl Sender {
+    pub fn new(ring: Rc<RefCell<command::Ring>>, receiver: Rc<RefCell<Receiver>>) -> Self {
+        Self {
+            ring,
+            receiver,
+            waker: Rc::new(RefCell::new(AtomicWaker::new())),
+        }
+    }
+
     pub async fn enable_device_slot(&mut self) -> Result<u8, command::Error> {
         let addr_to_trb = self.ring.borrow_mut().send_enable_slot()?;
         self.register_to_receiver(addr_to_trb);
@@ -48,14 +47,6 @@ impl Sender {
         self.register_to_receiver(addr_to_trb);
         self.get_trb(addr_to_trb).await;
         Ok(())
-    }
-
-    fn new(ring: Rc<RefCell<command::Ring>>, receiver: Rc<RefCell<Receiver>>) -> Self {
-        Self {
-            ring,
-            receiver,
-            waker: Rc::new(RefCell::new(AtomicWaker::new())),
-        }
     }
 
     fn register_to_receiver(&mut self, addr_to_trb: PhysAddr) {

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -50,7 +50,11 @@ fn init(
     let dcbaa = Rc::new(RefCell::new(DeviceContextBaseAddressArray::new(
         registers.clone(),
     )));
-    let (sender, receiver) = exchanger::command::channel(command_ring.clone());
+    let receiver = Rc::new(RefCell::new(Receiver::new()));
+    let sender = Rc::new(LocalMutex::new(
+        Sender::new(command_ring.clone(), receiver.clone()),
+        false,
+    ));
 
     xhc.init();
 


### PR DESCRIPTION
This reverts commit 0dc9a5a7672ca5398fe922f81c4559a5101ace29.

To use receiver from transfer exchanger.

bors r+
