### PR TITLE
Rewrite transfer TRBs with `bit_field` and `add_trb`

### DIFF
--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::super::{raw, CycleBit};
+use crate::add_trb;
+use bit_field::BitField;
 use bitfield::bitfield;
 use core::convert::TryFrom;
 use os_units::Bytes;
@@ -29,20 +31,35 @@ impl From<Trb> for raw::Trb {
     }
 }
 
-pub type SetupStage = SetupStageStructure<[u32; 4]>;
-bitfield! {
-    #[repr(transparent)]
-    pub struct SetupStageStructure([u32]);
-    impl Debug;
-    u128, _, set_bm_request_type: 7, 0;
-    u128, _, set_b_request: 15, 8;
-    u128, _, set_w_value: 31, 16;
-    u128, _, set_w_index: 32+15, 32;
-    u128, _, set_w_length: 32+31, 32+16;
-    u128, _, set_trb_transfer_length: 64+16, 64;
-    u128, _, set_cycle_bit: 96;
-    u128, _, set_trb_type: 96+15, 96+10;
-    u128, _, set_trt: 96+17, 96+16;
+add_trb!(SetupStage);
+impl SetupStage {
+    fn set_request_type(&mut self, t: u8) {
+        self.0[0].set_bits(0..=7, t.into());
+    }
+
+    fn set_request(&mut self, r: u8) {
+        self.0[0].set_bits(8..=15, r.into());
+    }
+
+    fn set_value(&mut self, v: u16) {
+        self.0[0].set_bits(16..=31, v.into());
+    }
+
+    fn set_index(&mut self, i: u16) {
+        self.0[1].set_bits(0..=15, i.into());
+    }
+
+    fn set_length(&mut self, l: u16) {
+        self.0[1].set_bits(16..=31, l.into());
+    }
+
+    fn set_trb_transfer_length(&mut self, l: u32) {
+        self.0[2].set_bits(0..=16, l.into());
+    }
+
+    fn set_trt(&mut self, t: u8) {
+        self.0[3].set_bits(16..=17, t.into());
+    }
 }
 
 pub type DataStage = DataStageStructure<[u32; 4]>;

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -85,14 +85,7 @@ impl DataStage {
     }
 }
 
-pub type StatusStage = StatusStageStructure<[u32; 4]>;
-bitfield! {
-    #[repr(transparent)]
-    pub struct StatusStageStructure([u32]);
-    impl Debug;
-    _, set_cycle_bit: 96;
-    u128, _, set_trb_type: 96+15, 96+10;
-}
+add_trb!(StatusStage);
 
 pub type TransferEvent = TransferEventStructure<[u32; 4]>;
 bitfield! {

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -54,7 +54,7 @@ impl SetupStage {
     }
 
     fn set_trb_transfer_length(&mut self, l: u32) {
-        self.0[2].set_bits(0..=16, l.into());
+        self.0[2].set_bits(0..=16, l);
     }
 
     fn set_trt(&mut self, t: u8) {


### PR DESCRIPTION
- refactor: rewrite `SetupStage` with `bit_flags` and `add_trb`
- refactor: rewrite `DataStage` with `bit_fields` and `add_trb`
- refactor: remove an unnecessary `into`
- refactor: rewrite `StatusStage` with `add_trb`

bors r+
