### PR TITLE
Move the definition of transfer event to `event::trb`

### DIFF
--- a/kernel/src/device/pci/xhci/structures/ring/event/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/event/trb.rs
@@ -3,6 +3,7 @@
 use super::super::raw;
 use crate::add_trb;
 use bit_field::BitField;
+use bitfield::bitfield;
 use core::convert::{TryFrom, TryInto};
 use os_units::Bytes;
 
@@ -67,6 +68,13 @@ impl TryFrom<raw::Trb> for PortStatusChange {
             Err(Error::UnrecognizedId)
         }
     }
+}
+
+pub type TransferEvent = TransferEventStructure<[u32; 4]>;
+bitfield! {
+    #[repr(transparent)]
+    pub struct TransferEventStructure([u32]);
+    impl Debug;
 }
 
 #[derive(Debug)]

--- a/kernel/src/device/pci/xhci/structures/ring/event/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/event/trb.rs
@@ -70,12 +70,7 @@ impl TryFrom<raw::Trb> for PortStatusChange {
     }
 }
 
-pub type TransferEvent = TransferEventStructure<[u32; 4]>;
-bitfield! {
-    #[repr(transparent)]
-    pub struct TransferEventStructure([u32]);
-    impl Debug;
-}
+add_trb!(TransferEvent);
 
 #[derive(Debug)]
 pub enum Error {

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -87,13 +87,6 @@ impl DataStage {
 
 add_trb!(StatusStage);
 
-pub type TransferEvent = TransferEventStructure<[u32; 4]>;
-bitfield! {
-    #[repr(transparent)]
-    pub struct TransferEventStructure([u32]);
-    impl Debug;
-}
-
 #[derive(Debug)]
 pub enum Error {
     UnrecognizedId,


### PR DESCRIPTION
- refactor: move the definition of transfer event TRB to `event::trb`
- refactor: rewrite `TransferEvent` with `add_trb`

bors r+
