### PR TITLE
Define `new` method for TRBs used to get descriptor

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -43,4 +43,3 @@ os_units = "0.2.0"
 bitfield = "0.13.2"
 bit_field = "0.10.1"
 futures-intrusive = { version = "0.4.0", default-features = false}
-bitflags = "1.2.1"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -43,3 +43,4 @@ os_units = "0.2.0"
 bitfield = "0.13.2"
 bit_field = "0.10.1"
 futures-intrusive = { version = "0.4.0", default-features = false}
+bitflags = "1.2.1"

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -34,7 +34,7 @@ add_trb!(SetupStage);
 impl SetupStage {
     const ID: u8 = 2;
 
-    fn new_get_descriptor<T>(b: &PageBox<T>, dti: DescTyIndex, c: CycleBit) -> Self {
+    fn new_get_descriptor<T>(b: &PageBox<T>, dti: DescTyIdx, c: CycleBit) -> Self {
         let mut t = Self::null();
         t.set_request_type(0b1000_0000);
         t.set_request(Request::GetDescriptor);
@@ -80,11 +80,11 @@ impl SetupStage {
     }
 }
 
-struct DescTyIndex {
+struct DescTyIdx {
     ty: DescTy,
     i: u8,
 }
-impl DescTyIndex {
+impl DescTyIdx {
     fn new(ty: DescTy, i: u8) -> Self {
         Self { ty, i }
     }

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -103,6 +103,18 @@ enum DescTy {
 
 add_trb!(DataStage);
 impl DataStage {
+    const ID: u8 = 3;
+
+    fn new<T>(b: &PageBox<T>, c: CycleBit, d: Dir) -> Self {
+        let mut t = Self::null();
+        t.set_data_buf(b.phys_addr());
+        t.set_transfer_length(b.bytes().as_usize().try_into().unwrap());
+        t.set_cycle_bit(c);
+        t.set_trb_type(Self::ID);
+        t.set_dir(d);
+        t
+    }
+
     fn null() -> Self {
         Self([0; 4])
     }

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -123,8 +123,21 @@ impl DataStage {
         self.0[2].set_bits(17..=21, s.into());
     }
 
-    fn set_dir(&mut self, d: bool) {
-        self.0[3].set_bit(16, d);
+    fn set_dir(&mut self, d: Dir) {
+        self.0[3].set_bit(16, d.into());
+    }
+}
+
+enum Dir {
+    Out = 0,
+    In = 1,
+}
+impl From<Dir> for bool {
+    fn from(d: Dir) -> Self {
+        match d {
+            Dir::Out => false,
+            Dir::In => true,
+        }
     }
 }
 

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -34,6 +34,10 @@ impl From<Trb> for raw::Trb {
 
 add_trb!(SetupStage);
 impl SetupStage {
+    fn null() -> Self {
+        Self([0; 4])
+    }
+
     fn set_request_type(&mut self, t: u8) {
         self.0[0].set_bits(0..=7, t.into());
     }

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -155,6 +155,16 @@ impl From<Direction> for bool {
 
 add_trb!(StatusStage);
 impl StatusStage {
+    const ID: u8 = 4;
+
+    fn new(c: CycleBit) -> Self {
+        let mut t = Self::null();
+        t.set_cycle_bit(c);
+        t.set_ioc(true);
+        t.set_trb_type(Self::ID);
+        t
+    }
+
     fn null() -> Self {
         Self([0; 4])
     }

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -155,6 +155,10 @@ impl From<Direction> for bool {
 
 add_trb!(StatusStage);
 impl StatusStage {
+    fn null() -> Self {
+        Self([0; 4])
+    }
+
     fn set_ioc(&mut self, ioc: bool) {
         self.0[3].set_bit(5, ioc);
     }

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -4,7 +4,6 @@ use super::super::{raw, CycleBit};
 use crate::add_trb;
 use bit_field::BitField;
 use bitfield::bitfield;
-use bitflags::bitflags;
 use core::convert::{TryFrom, TryInto};
 use os_units::Bytes;
 use x86_64::PhysAddr;
@@ -71,10 +70,8 @@ enum Request {
     GetDescriptor = 6,
 }
 
-bitflags! {
-    struct DescTy:u8{
-        const DEVICE=1;
-    }
+enum DescTy {
+    Device = 1,
 }
 
 add_trb!(DataStage);

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -103,6 +103,10 @@ enum DescTy {
 
 add_trb!(DataStage);
 impl DataStage {
+    fn null() -> Self {
+        Self([0; 4])
+    }
+
     fn set_data_buf(&mut self, b: PhysAddr) {
         let l = b.as_u64() & 0xffff_ffff;
         let u = b.as_u64() >> 32;

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -105,7 +105,7 @@ add_trb!(DataStage);
 impl DataStage {
     const ID: u8 = 3;
 
-    fn new<T>(b: &PageBox<T>, c: CycleBit, d: Dir) -> Self {
+    fn new<T>(b: &PageBox<T>, c: CycleBit, d: Direction) -> Self {
         let mut t = Self::null();
         t.set_data_buf(b.phys_addr());
         t.set_transfer_length(b.bytes().as_usize().try_into().unwrap());
@@ -135,20 +135,20 @@ impl DataStage {
         self.0[2].set_bits(17..=21, s.into());
     }
 
-    fn set_dir(&mut self, d: Dir) {
+    fn set_dir(&mut self, d: Direction) {
         self.0[3].set_bit(16, d.into());
     }
 }
 
-enum Dir {
+enum Direction {
     Out = 0,
     In = 1,
 }
-impl From<Dir> for bool {
-    fn from(d: Dir) -> Self {
+impl From<Direction> for bool {
+    fn from(d: Direction) -> Self {
         match d {
-            Dir::Out => false,
-            Dir::In => true,
+            Direction::Out => false,
+            Direction::In => true,
         }
     }
 }

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -4,6 +4,7 @@ use super::super::{raw, CycleBit};
 use crate::add_trb;
 use bit_field::BitField;
 use bitfield::bitfield;
+use bitflags::bitflags;
 use core::convert::{TryFrom, TryInto};
 use os_units::Bytes;
 use x86_64::PhysAddr;
@@ -59,6 +60,12 @@ impl SetupStage {
 
     fn set_trt(&mut self, t: u8) {
         self.0[3].set_bits(16..=17, t.into());
+    }
+}
+
+bitflags! {
+    struct DescTy:u8{
+        const DEVICE=1;
     }
 }
 

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::super::{raw, CycleBit};
-use crate::add_trb;
+use crate::{add_trb, mem::allocator::page_box::PageBox};
 use bit_field::BitField;
 use core::convert::{TryFrom, TryInto};
 use os_units::Bytes;
@@ -32,6 +32,21 @@ impl From<Trb> for raw::Trb {
 
 add_trb!(SetupStage);
 impl SetupStage {
+    const ID: u8 = 2;
+
+    fn new_get_descriptor<T>(b: &PageBox<T>, dt: DescTy, desc_i: u8, c: CycleBit) -> Self {
+        let mut t = Self::null();
+        t.set_request_type(0b1000_0000);
+        t.set_request(Request::GetDescriptor);
+        t.set_value((dt as u16) << 8 | desc_i as u16);
+        t.set_length(b.bytes().as_usize().try_into().unwrap());
+        t.set_trb_transfer_length(8);
+        t.set_cycle_bit(c);
+        t.set_trb_type(Self::ID);
+        t.set_trt(3);
+        t
+    }
+
     fn null() -> Self {
         Self([0; 4])
     }

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -34,11 +34,11 @@ add_trb!(SetupStage);
 impl SetupStage {
     const ID: u8 = 2;
 
-    fn new_get_descriptor<T>(b: &PageBox<T>, dt: DescTy, desc_i: u8, c: CycleBit) -> Self {
+    fn new_get_descriptor<T>(b: &PageBox<T>, dti: DescTyIndex, c: CycleBit) -> Self {
         let mut t = Self::null();
         t.set_request_type(0b1000_0000);
         t.set_request(Request::GetDescriptor);
-        t.set_value((dt as u16) << 8 | desc_i as u16);
+        t.set_value(dti.bits());
         t.set_length(b.bytes().as_usize().try_into().unwrap());
         t.set_trb_transfer_length(8);
         t.set_cycle_bit(c);
@@ -77,6 +77,19 @@ impl SetupStage {
 
     fn set_trt(&mut self, t: u8) {
         self.0[3].set_bits(16..=17, t.into());
+    }
+}
+
+struct DescTyIndex {
+    ty: DescTy,
+    i: u8,
+}
+impl DescTyIndex {
+    fn new(ty: DescTy, i: u8) -> Self {
+        Self { ty, i }
+    }
+    fn bits(self) -> u16 {
+        (self.ty as u16) << 8 | u16::from(self.i)
     }
 }
 

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -154,6 +154,11 @@ impl From<Direction> for bool {
 }
 
 add_trb!(StatusStage);
+impl StatusStage {
+    fn set_ioc(&mut self, ioc: bool) {
+        self.0[3].set_bit(5, ioc);
+    }
+}
 
 #[derive(Debug)]
 pub enum Error {

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb.rs
@@ -42,8 +42,8 @@ impl SetupStage {
         self.0[0].set_bits(0..=7, t.into());
     }
 
-    fn set_request(&mut self, r: u8) {
-        self.0[0].set_bits(8..=15, r.into());
+    fn set_request(&mut self, r: Request) {
+        self.0[0].set_bits(8..=15, r as _);
     }
 
     fn set_value(&mut self, v: u16) {
@@ -65,6 +65,10 @@ impl SetupStage {
     fn set_trt(&mut self, t: u8) {
         self.0[3].set_bits(16..=17, t.into());
     }
+}
+
+enum Request {
+    GetDescriptor = 6,
 }
 
 bitflags! {

--- a/kernel/src/mem/allocator/page_box.rs
+++ b/kernel/src/mem/allocator/page_box.rs
@@ -137,6 +137,10 @@ impl<T: ?Sized> PageBox<T> {
         PML4.lock().translate_addr(self.virt).unwrap()
     }
 
+    pub fn bytes(&self) -> Bytes {
+        self.bytes
+    }
+
     fn new_zeroed_from_bytes(bytes: Bytes) -> Self {
         let virt = Self::allocate_pages(bytes.as_num_of_pages());
 


### PR DESCRIPTION
- chore: define `DescTy`
- chore: define `SetupStage::null`
- chore: define `Request`
- refactor: rewrite `DescTy` with enum
- chore: define `PageBox::bytes`
- chore: define `SetupStage::new_get_descriptor`
- refactor: define `DescTyIndex`
- refactor: shorten struct name
- chore: define `DataStage::null`
- chore: define `Dir`
- chore: define `DataStage::new`
- refactor: rename `Dir` to `Direction`
- chore: define `StatusStage::set_ioc`
- chore: define `StatusStage::null`
- chore: define `StatusStage`

bors r+
