### PR TITLE
Split command ring into structure and manager

### DIFF
--- a/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::{super::registers::Registers, raw, CycleBit};
+use crate::mem::allocator::page_box::PageBox;
 use alloc::rc::Rc;
+use bit_field::BitField;
 use core::cell::RefCell;
 use trb::Trb;
 use x86_64::PhysAddr;
@@ -121,6 +123,107 @@ impl<'a> Ring {
     fn move_enqueue_ptr_to_the_beginning(&mut self) {
         self.enqueue_ptr = 0;
         self.cycle_bit.toggle();
+    }
+}
+
+struct Raw {
+    raw: PageBox<[[u32; 4]]>,
+    enq_p: usize,
+    c: CycleBit,
+}
+impl Raw {
+    fn new() -> Self {
+        Self {
+            raw: PageBox::new_slice([0; 4], SIZE_OF_RING),
+            enq_p: 0,
+            c: CycleBit::new(true),
+        }
+    }
+
+    fn try_enqueue(&mut self, trb: Trb) -> Result<PhysAddr, Error> {
+        if self.enqueueable() {
+            Ok(self.enqueue(trb))
+        } else {
+            Err(Error::QueueIsFull)
+        }
+    }
+
+    fn enqueueable(&self) -> bool {
+        !self.full() && self.has_space_for_link_trb()
+    }
+
+    fn full(&self) -> bool {
+        self.writable(self.enq_p)
+    }
+
+    fn has_space_for_link_trb(&self) -> bool {
+        if self.wrapping_back_happens() {
+            self.writable(self.next_enq_p())
+        } else {
+            true
+        }
+    }
+
+    fn wrapping_back_happens(&self) -> bool {
+        self.next_enq_p() == 0
+    }
+
+    fn writable(&self, i: usize) -> bool {
+        self.c_bit(i) != self.c
+    }
+
+    fn c_bit(&self, i: usize) -> CycleBit {
+        let t = self.raw[i];
+        CycleBit::new(t[3].get_bit(0))
+    }
+
+    fn next_enq_p(&self) -> usize {
+        (self.enq_p + 1) % SIZE_OF_RING
+    }
+
+    fn enqueue(&mut self, trb: Trb) -> PhysAddr {
+        self.write_trb(trb);
+        let trb_a = self.enq_addr();
+        self.increment();
+        trb_a
+    }
+
+    fn write_trb(&mut self, trb: Trb) {
+        self.raw[self.enq_p] = trb.into();
+    }
+
+    fn increment(&mut self) {
+        self.enq_p += 1;
+        if !self.enq_p_within_ring() {
+            self.enq_link();
+            self.move_enq_p_to_the_beginning();
+        }
+    }
+
+    fn enq_p_within_ring(&self) -> bool {
+        self.enq_p < self.len() - 1
+    }
+
+    fn enq_link(&mut self) {
+        // Don't call `enqueue`. It will return an `Err` value as there is no space for link TRB.
+        self.raw[self.enq_p] = Trb::new_link(self.head_addr(), self.c).into();
+    }
+
+    fn move_enq_p_to_the_beginning(&mut self) {
+        self.enq_p = 0;
+        self.c.toggle();
+    }
+
+    fn enq_addr(&self) -> PhysAddr {
+        self.head_addr() + Trb::SIZE.as_usize() * self.enq_p
+    }
+
+    fn head_addr(&self) -> PhysAddr {
+        self.raw.phys_addr()
+    }
+
+    fn len(&self) -> usize {
+        self.raw.len()
     }
 }
 

--- a/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
@@ -48,7 +48,7 @@ impl<'a> Ring {
         Ok(phys_addr_to_trb)
     }
 
-    pub fn phys_addr(&self) -> PhysAddr {
+    fn phys_addr(&self) -> PhysAddr {
         self.raw.head_addr()
     }
 

--- a/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
@@ -38,6 +38,16 @@ impl From<Trb> for raw::Trb {
         }
     }
 }
+impl From<Trb> for [u32; 4] {
+    fn from(t: Trb) -> Self {
+        match t {
+            Trb::Noop(n) => n.0,
+            Trb::Link(l) => l.0,
+            Trb::EnableSlot(e) => e.0,
+            Trb::AddressDevice(a) => a.0,
+        }
+    }
+}
 
 add_trb!(Link);
 impl Link {

--- a/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
@@ -16,16 +16,25 @@ pub enum Trb {
 impl Trb {
     pub const SIZE: Bytes = Bytes::new(16);
 
-    pub fn new_enable_slot(c: CycleBit) -> Self {
-        Self::EnableSlot(EnableSlot::new(c))
+    pub fn new_enable_slot() -> Self {
+        Self::EnableSlot(EnableSlot::new())
     }
 
-    pub fn new_link(a: PhysAddr, c: CycleBit) -> Self {
-        Self::Link(Link::new(a, c))
+    pub fn new_link(a: PhysAddr) -> Self {
+        Self::Link(Link::new(a))
     }
 
-    pub fn new_address_device(c: CycleBit, input_context_addr: PhysAddr, slot_id: u8) -> Self {
-        Self::AddressDevice(AddressDevice::new(c, input_context_addr, slot_id))
+    pub fn new_address_device(input_context_addr: PhysAddr, slot_id: u8) -> Self {
+        Self::AddressDevice(AddressDevice::new(input_context_addr, slot_id))
+    }
+
+    pub fn set_c(&mut self, c: CycleBit) {
+        match self {
+            Self::Noop(n) => n.set_cycle_bit(c),
+            Self::Link(l) => l.set_cycle_bit(c),
+            Self::EnableSlot(e) => e.set_cycle_bit(c),
+            Self::AddressDevice(a) => a.set_cycle_bit(c),
+        }
     }
 }
 impl From<Trb> for raw::Trb {
@@ -52,10 +61,9 @@ impl From<Trb> for [u32; 4] {
 add_trb!(Link);
 impl Link {
     const ID: u8 = 6;
-    fn new(addr_to_ring: PhysAddr, cycle_bit: CycleBit) -> Self {
+    fn new(addr_to_ring: PhysAddr) -> Self {
         assert!(addr_to_ring.is_aligned(u64::try_from(Trb::SIZE.as_usize()).unwrap()));
         let mut trb = Self([0; 4]);
-        trb.set_cycle_bit(cycle_bit);
         trb.set_trb_type(Self::ID);
         trb.set_addr(addr_to_ring.as_u64());
         trb
@@ -77,9 +85,8 @@ impl From<raw::Trb> for Link {
 add_trb!(EnableSlot);
 impl EnableSlot {
     const ID: u8 = 9;
-    pub fn new(cycle_bit: CycleBit) -> Self {
+    pub fn new() -> Self {
         let mut enable_slot = Self([0; 4]);
-        enable_slot.set_cycle_bit(cycle_bit);
         enable_slot.set_trb_type(Self::ID);
         enable_slot
     }
@@ -93,12 +100,11 @@ impl From<raw::Trb> for EnableSlot {
 add_trb!(AddressDevice);
 impl AddressDevice {
     const ID: u8 = 11;
-    pub fn new(cycle_bit: CycleBit, addr_to_input_context: PhysAddr, slot_id: u8) -> Self {
+    pub fn new(addr_to_input_context: PhysAddr, slot_id: u8) -> Self {
         let mut trb = Self([0; 4]);
 
         assert!(addr_to_input_context.is_aligned(16_u64));
         trb.set_input_context_ptr_as_u64(addr_to_input_context.as_u64());
-        trb.set_cycle_bit(cycle_bit);
         trb.set_trb_type(Self::ID);
         trb.set_slot_id(slot_id);
         trb

--- a/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
@@ -96,6 +96,11 @@ impl From<raw::Trb> for EnableSlot {
         Self(raw.0)
     }
 }
+impl Default for EnableSlot {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 add_trb!(AddressDevice);
 impl AddressDevice {


### PR DESCRIPTION
- chore: implement `Trb::from`
- chore: define `command::Raw`
- refactor: use newly defined `Raw`
- refactor: define an unnecessary `pub`

bors r+
