### PR TITLE
refactor: remove an unnecessary lifetime notation

### DIFF
--- a/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
@@ -17,7 +17,7 @@ pub struct Ring {
     raw: Raw,
     registers: Rc<RefCell<Registers>>,
 }
-impl<'a> Ring {
+impl Ring {
     pub fn new(registers: Rc<RefCell<Registers>>) -> Self {
         Self {
             raw: Raw::new(),


### PR DESCRIPTION
bors r+
