### PR TITLE
Split the internal structure of transfer ring

### DIFF
--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -75,7 +75,7 @@ impl Port {
             input_context: context::Input::null(&registers),
             output_device_context: PageBox::new(context::Device::null()),
             dcbaa,
-            transfer_ring: transfer::Ring::new(registers),
+            transfer_ring: transfer::Ring::new(),
         }
     }
 

--- a/kernel/src/device/pci/xhci/port.rs
+++ b/kernel/src/device/pci/xhci/port.rs
@@ -35,7 +35,7 @@ pub fn spawn_tasks(
     task_collection: &Rc<RefCell<task::Collection>>,
 ) {
     for i in 0..num_of_ports(&registers) {
-        let port = Port::new(registers.clone(), dcbaa.clone(), i + 1);
+        let port = Port::new(&registers, dcbaa.clone(), i + 1);
         if port.connected() {
             task_collection
                 .borrow_mut()
@@ -65,14 +65,14 @@ impl Port {
     }
 
     fn new(
-        registers: Rc<RefCell<Registers>>,
+        registers: &Rc<RefCell<Registers>>,
         dcbaa: Rc<RefCell<DeviceContextBaseAddressArray>>,
         index: usize,
     ) -> Self {
         Self {
             registers: registers.clone(),
             index,
-            input_context: context::Input::null(&registers),
+            input_context: context::Input::null(registers),
             output_device_context: PageBox::new(context::Device::null()),
             dcbaa,
             transfer_ring: transfer::Ring::new(),

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/mod.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use super::{super::registers::Registers, raw, CycleBit};
+use super::CycleBit;
 use crate::mem::allocator::page_box::PageBox;
-use alloc::rc::Rc;
 use bit_field::BitField;
-use core::cell::RefCell;
 use trb::Trb;
 use x86_64::PhysAddr;
 

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
@@ -44,6 +44,11 @@ impl From<Trb> for raw::Trb {
         unimplemented!()
     }
 }
+impl From<Trb> for [u32; 4] {
+    fn from(t: Trb) -> Self {
+        unimplemented!()
+    }
+}
 
 #[derive(Debug)]
 pub enum Error {


### PR DESCRIPTION
- refactor: split `transfer::Ring` into two
- refactor: remove unused imports

bors r+
