### PR TITLE
Move the definition of the Link TRB

### DIFF
--- a/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use super::super::CycleBit;
+use super::super::{CycleBit, Link};
 use crate::add_trb;
 use bit_field::BitField;
-use core::convert::{TryFrom, TryInto};
+use core::convert::TryInto;
 use os_units::Bytes;
 use x86_64::PhysAddr;
 
@@ -45,25 +45,6 @@ impl From<Trb> for [u32; 4] {
             Trb::EnableSlot(e) => e.0,
             Trb::AddressDevice(a) => a.0,
         }
-    }
-}
-
-add_trb!(Link);
-impl Link {
-    const ID: u8 = 6;
-    fn new(addr_to_ring: PhysAddr) -> Self {
-        assert!(addr_to_ring.is_aligned(u64::try_from(Trb::SIZE.as_usize()).unwrap()));
-        let mut trb = Self([0; 4]);
-        trb.set_trb_type(Self::ID);
-        trb.set_addr(addr_to_ring.as_u64());
-        trb
-    }
-
-    fn set_addr(&mut self, a: u64) {
-        let l = a & 0xffff_ffff;
-        let u = a >> 32;
-        self.0[0] = l.try_into().unwrap();
-        self.0[1] = u.try_into().unwrap();
     }
 }
 

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/mod.rs
@@ -89,7 +89,9 @@ impl Raw {
     }
 
     fn append_link_trb(&mut self) {
-        self.ring[self.enq_p] = Trb::new_link(self.phys_addr()).into();
+        let mut t = Trb::new_link(self.phys_addr());
+        t.set_c(self.c);
+        self.ring[self.enq_p] = t.into();
     }
 
     fn move_enqueue_ptr_to_the_beginning(&mut self) {

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/mod.rs
@@ -89,7 +89,7 @@ impl Raw {
     }
 
     fn append_link_trb(&mut self) {
-        self.ring[self.enq_p] = Trb::new_link(self.phys_addr(), self.c).into();
+        self.ring[self.enq_p] = Trb::new_link(self.phys_addr()).into();
     }
 
     fn move_enqueue_ptr_to_the_beginning(&mut self) {

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use super::super::CycleBit;
+use super::super::{CycleBit, Link};
 use crate::mem::allocator::page_box::PageBox;
 use control::{Control, DescTyIdx};
 use core::convert::TryFrom;
@@ -11,6 +11,7 @@ mod control;
 
 pub enum Trb {
     Control(Control),
+    Link(Link),
 }
 impl Trb {
     pub const SIZE: Bytes = Bytes::new(16);
@@ -28,8 +29,8 @@ impl Trb {
         )
     }
 
-    pub fn new_link(a: PhysAddr, c: CycleBit) -> Self {
-        unimplemented!()
+    pub fn new_link(a: PhysAddr) -> Self {
+        Self::Link(Link::new(a))
     }
 }
 impl From<Trb> for [u32; 4] {

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
@@ -31,6 +31,13 @@ impl Trb {
     pub fn new_link(a: PhysAddr) -> Self {
         Self::Link(Link::new(a))
     }
+
+    pub fn set_c(&mut self, c: CycleBit) {
+        match self {
+            Self::Control(_) => unimplemented!(),
+            Self::Link(l) => l.set_cycle_bit(c),
+        }
+    }
 }
 impl From<Trb> for [u32; 4] {
     fn from(t: Trb) -> Self {

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
@@ -3,7 +3,6 @@
 use super::super::{CycleBit, Link};
 use crate::mem::allocator::page_box::PageBox;
 use control::{Control, DescTyIdx};
-use core::convert::TryFrom;
 use os_units::Bytes;
 use x86_64::PhysAddr;
 


### PR DESCRIPTION
- refactor: move the definition of link TRB to `ring` module
- chore: implement `new_link`
- refactor: remove an unused import
- fix: arguments
- refactor: define `set_c`
- chore: set c bit before enqueueing

bors r+
