### PR TITLE
Create TRBs inside exchanger code

### DIFF
--- a/kernel/src/device/pci/xhci/exchanger/command.rs
+++ b/kernel/src/device/pci/xhci/exchanger/command.rs
@@ -43,11 +43,11 @@ impl Sender {
 
     async fn issue_trb(&mut self, t: Trb) -> Result<CommandCompletion, command::Error> {
         let a = self.ring.borrow_mut().try_enqueue(t)?;
-        self.register_to_receiver(a);
+        self.register_with_receiver(a);
         Ok(self.get_trb(a).await)
     }
 
-    fn register_to_receiver(&mut self, addr_to_trb: PhysAddr) {
+    fn register_with_receiver(&mut self, addr_to_trb: PhysAddr) {
         self.receiver
             .borrow_mut()
             .add_entry(addr_to_trb, self.waker.clone())

--- a/kernel/src/device/pci/xhci/exchanger/command.rs
+++ b/kernel/src/device/pci/xhci/exchanger/command.rs
@@ -8,12 +8,7 @@ use super::{
     receiver::{ReceiveFuture, Receiver},
 };
 use alloc::rc::Rc;
-use core::{
-    cell::RefCell,
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
-};
+use core::cell::RefCell;
 use futures_util::task::AtomicWaker;
 use x86_64::PhysAddr;
 


### PR DESCRIPTION
- refactor: don't create TRBs inside Ring code
- refactor: remove unused imports
- refactor: define `issue_trb`
- fix: grammer mistake

bors r+
