### PR TITLE
Define `Context` type

### DIFF
--- a/kernel/src/device/pci/xhci/structures/context.rs
+++ b/kernel/src/device/pci/xhci/structures/context.rs
@@ -7,13 +7,13 @@ use x86_64::PhysAddr;
 
 pub struct Context {
     pub input: Input,
-    pub output_device: Device,
+    pub output_device: PageBox<Device>,
 }
 impl Context {
     pub fn new(r: &Registers) -> Self {
         Self {
             input: Input::null(r),
-            output_device: Device::null(),
+            output_device: PageBox::new(Device::null()),
         }
     }
 }

--- a/kernel/src/device/pci/xhci/structures/context.rs
+++ b/kernel/src/device/pci/xhci/structures/context.rs
@@ -5,6 +5,19 @@ use crate::mem::allocator::page_box::PageBox;
 use bitfield::bitfield;
 use x86_64::PhysAddr;
 
+pub struct Context {
+    pub input: Input,
+    pub output_device: Device,
+}
+impl Context {
+    pub fn new(r: &Registers) -> Self {
+        Self {
+            input: Input::null(r),
+            output_device: Device::null(),
+        }
+    }
+}
+
 pub enum Input {
     Bit32(PageBox<InputWithControl32Bit>),
     Bit64(PageBox<InputWithControl64Bit>),


### PR DESCRIPTION
- chore: define `Context`
- fix: allocate `output_device` inside page box
- refactor: rewrite with `Context`

bors r+
