### PR TITLE
Split a method

### DIFF
--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -87,12 +87,7 @@ impl Port {
     }
 
     fn init_context(&mut self) {
-        context::Initializer::new(
-            &mut self.context,
-            &self.transfer_ring,
-            self.index.try_into().unwrap(),
-        )
-        .init();
+        context::Initializer::new(&mut self.context, &self.transfer_ring, self.index).init();
     }
 
     fn register_to_dcbaa(&mut self, slot_id: usize) {

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -45,14 +45,14 @@ pub fn spawn_tasks(
     }
 }
 
-fn num_of_ports(registers: &Rc<RefCell<Registers>>) -> usize {
+fn num_of_ports(registers: &Rc<RefCell<Registers>>) -> u8 {
     let params1 = registers.borrow().capability.hcs_params_1.read();
-    params1.max_ports().into()
+    params1.max_ports()
 }
 
 pub struct Port {
     registers: Rc<RefCell<Registers>>,
-    index: usize,
+    index: u8,
     context: Context,
     transfer_ring: transfer::Ring,
     dcbaa: Rc<RefCell<DeviceContextBaseAddressArray>>,
@@ -61,7 +61,7 @@ impl Port {
     fn new(
         registers: &Rc<RefCell<Registers>>,
         dcbaa: Rc<RefCell<DeviceContextBaseAddressArray>>,
-        index: usize,
+        index: u8,
     ) -> Self {
         Self {
             registers: registers.clone(),
@@ -113,6 +113,6 @@ impl Port {
 
     fn read_port_rg(&self) -> PortRegisters {
         let port_rg = &self.registers.borrow().operational.port_registers;
-        port_rg.read(self.index - 1)
+        port_rg.read((self.index - 1).into())
     }
 }

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -81,12 +81,7 @@ impl Port {
     }
 
     async fn init_device_slot(&mut self, slot_id: u8, runner: Rc<LocalMutex<Sender>>) {
-        context::Initializer::new(
-            &mut self.context,
-            &self.transfer_ring,
-            self.index.try_into().unwrap(),
-        )
-        .init();
+        self.init_context();
         self.register_to_dcbaa(slot_id.into());
 
         runner
@@ -94,6 +89,15 @@ impl Port {
             .await
             .address_device(self.addr_to_input_context(), slot_id)
             .await;
+    }
+
+    fn init_context(&mut self) {
+        context::Initializer::new(
+            &mut self.context,
+            &self.transfer_ring,
+            self.index.try_into().unwrap(),
+        )
+        .init();
     }
 
     fn addr_to_input_context(&self) -> PhysAddr {

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -100,12 +100,12 @@ impl Port {
         .init();
     }
 
-    fn addr_to_input_context(&self) -> PhysAddr {
-        self.context.input.phys_addr()
-    }
-
     fn register_to_dcbaa(&mut self, slot_id: usize) {
         self.dcbaa.borrow_mut()[slot_id] = self.context.output_device.phys_addr();
+    }
+
+    fn addr_to_input_context(&self) -> PhysAddr {
+        self.context.input.phys_addr()
     }
 
     fn read_port_rg(&self) -> PortRegisters {

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -83,12 +83,7 @@ impl Port {
     async fn init_device_slot(&mut self, slot_id: u8, runner: Rc<LocalMutex<Sender>>) {
         self.init_context();
         self.register_to_dcbaa(slot_id.into());
-
-        runner
-            .lock()
-            .await
-            .address_device(self.addr_to_input_context(), slot_id)
-            .await;
+        self.issue_address_device(runner, slot_id).await;
     }
 
     fn init_context(&mut self) {
@@ -102,6 +97,14 @@ impl Port {
 
     fn register_to_dcbaa(&mut self, slot_id: usize) {
         self.dcbaa.borrow_mut()[slot_id] = self.context.output_device.phys_addr();
+    }
+
+    async fn issue_address_device(&mut self, runner: Rc<LocalMutex<Sender>>, slot_id: u8) {
+        runner
+            .lock()
+            .await
+            .address_device(self.addr_to_input_context(), slot_id)
+            .await;
     }
 
     fn addr_to_input_context(&self) -> PhysAddr {

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -103,11 +103,11 @@ impl Port {
         runner
             .lock()
             .await
-            .address_device(self.addr_to_input_context(), slot_id)
+            .address_device(self.input_context_addr(), slot_id)
             .await;
     }
 
-    fn addr_to_input_context(&self) -> PhysAddr {
+    fn input_context_addr(&self) -> PhysAddr {
         self.context.input.phys_addr()
     }
 

--- a/kernel/src/device/pci/xhci/port/resetter.rs
+++ b/kernel/src/device/pci/xhci/port/resetter.rs
@@ -8,10 +8,10 @@ use crate::device::pci::xhci::structures::registers::Registers;
 
 pub struct Resetter {
     registers: Rc<RefCell<Registers>>,
-    slot: usize,
+    slot: u8,
 }
 impl Resetter {
-    pub fn new(registers: Rc<RefCell<Registers>>, slot: usize) -> Self {
+    pub fn new(registers: Rc<RefCell<Registers>>, slot: u8) -> Self {
         Self { registers, slot }
     }
 
@@ -22,11 +22,11 @@ impl Resetter {
 
     fn start_resetting(&mut self) {
         let r = &mut self.registers.borrow_mut().operational.port_registers;
-        r.update(self.slot - 1, |r| r.port_sc.set_port_reset(true))
+        r.update((self.slot - 1).into(), |r| r.port_sc.set_port_reset(true))
     }
 
     fn wait_until_reset_is_completed(&self) {
         let r = &self.registers.borrow().operational.port_registers;
-        while !r.read(self.slot - 1).port_sc.port_reset_changed() {}
+        while !r.read((self.slot - 1).into()).port_sc.port_reset_changed() {}
     }
 }


### PR DESCRIPTION
- refactor: define `init_context` method
- refactor: reorder methods
- refactor: define `issue_address_device` method
- refactor: rename to `input_context_addr`
- refactor: `port` takes `u8` value

bors r+
