### PR TITLE
Write to doorbell registers after issueing TRBs

### DIFF
--- a/kernel/src/device/pci/xhci/exchanger/transfer.rs
+++ b/kernel/src/device/pci/xhci/exchanger/transfer.rs
@@ -22,14 +22,20 @@ pub struct Sender {
     ring: transfer::Ring,
     receiver: Rc<RefCell<Receiver>>,
     registers: Rc<RefCell<Registers>>,
+    slot_id: u8,
     waker: Rc<RefCell<AtomicWaker>>,
 }
 impl Sender {
-    pub fn new(receiver: Rc<RefCell<Receiver>>, registers: Rc<RefCell<Registers>>) -> Self {
+    pub fn new(
+        receiver: Rc<RefCell<Receiver>>,
+        registers: Rc<RefCell<Registers>>,
+        slot_id: u8,
+    ) -> Self {
         Self {
             ring: transfer::Ring::new(),
             receiver,
             registers,
+            slot_id,
             waker: Rc::new(RefCell::new(AtomicWaker::new())),
         }
     }

--- a/kernel/src/device/pci/xhci/exchanger/transfer.rs
+++ b/kernel/src/device/pci/xhci/exchanger/transfer.rs
@@ -4,6 +4,7 @@ use super::receiver::{ReceiveFuture, Receiver};
 use crate::{
     device::pci::xhci::structures::{
         descriptor,
+        registers::Registers,
         ring::{event::trb::completion::Completion, transfer},
     },
     mem::allocator::page_box::PageBox,
@@ -20,13 +21,15 @@ use x86_64::PhysAddr;
 pub struct Sender {
     ring: transfer::Ring,
     receiver: Rc<RefCell<Receiver>>,
+    registers: Rc<RefCell<Registers>>,
     waker: Rc<RefCell<AtomicWaker>>,
 }
 impl Sender {
-    pub fn new(receiver: Rc<RefCell<Receiver>>) -> Self {
+    pub fn new(receiver: Rc<RefCell<Receiver>>, registers: Rc<RefCell<Registers>>) -> Self {
         Self {
             ring: transfer::Ring::new(),
             receiver,
+            registers,
             waker: Rc::new(RefCell::new(AtomicWaker::new())),
         }
     }


### PR DESCRIPTION
- refactor: `transfer::Sender` takes `registers`
- chore: `transfer::Sender` also takes `slot_id`
- fix: forgot to write to doorbell registers after issueing TRBs

bors r+
