### PR TITLE
Not to create the Transfer Ring inside `transfer::Sender::new`

### DIFF
--- a/kernel/src/device/pci/xhci/exchanger/transfer.rs
+++ b/kernel/src/device/pci/xhci/exchanger/transfer.rs
@@ -27,21 +27,18 @@ pub struct Sender {
 }
 impl Sender {
     pub fn new(
+        ring: transfer::Ring,
         receiver: Rc<RefCell<Receiver>>,
         registers: Rc<RefCell<Registers>>,
         slot_id: u8,
     ) -> Self {
         Self {
-            ring: transfer::Ring::new(),
+            ring,
             receiver,
             registers,
             slot_id,
             waker: Rc::new(RefCell::new(AtomicWaker::new())),
         }
-    }
-
-    pub fn ring_addr(&self) -> PhysAddr {
-        self.ring.phys_addr()
     }
 
     pub async fn get_device_descriptor(&mut self) -> PageBox<descriptor::Device> {


### PR DESCRIPTION
- Revert "refactor: create an instance of `transfer::Ring` in `Sender::new`"
- fix: avoid exceeding the limit of the number of arguments

bors r+
