### PR TITLE
Get the device descriptor

### DIFF
--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -27,7 +27,7 @@ pub async fn task(task_collection: Rc<RefCell<task::Collection>>) {
         &runner,
         &dcbaa,
         &registers,
-        command_completion_receiver.clone(),
+        &command_completion_receiver.clone(),
         &task_collection,
     );
 

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -23,7 +23,13 @@ pub async fn task(task_collection: Rc<RefCell<task::Collection>>) {
     let (event_ring, dcbaa, runner, command_completion_receiver) =
         init(&registers, &task_collection);
 
-    port::spawn_tasks(&runner, &dcbaa, &registers, &task_collection);
+    port::spawn_tasks(
+        &runner,
+        &dcbaa,
+        &registers,
+        command_completion_receiver.clone(),
+        &task_collection,
+    );
 
     task_collection
         .borrow_mut()

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -27,7 +27,7 @@ pub async fn task(task_collection: Rc<RefCell<task::Collection>>) {
         &runner,
         &dcbaa,
         &registers,
-        &command_completion_receiver.clone(),
+        &command_completion_receiver,
         &task_collection,
     );
 

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -5,11 +5,15 @@ use super::{
     structures::{
         context::Context,
         dcbaa::DeviceContextBaseAddressArray,
+        descriptor,
         registers::{operational::PortRegisters, Registers},
         ring::transfer::Ring as TransferRing,
     },
 };
-use crate::multitask::task::{self, Task};
+use crate::{
+    mem::allocator::page_box::PageBox,
+    multitask::task::{self, Task},
+};
 use alloc::rc::Rc;
 use core::cell::RefCell;
 use futures_intrusive::sync::LocalMutex;
@@ -31,6 +35,8 @@ async fn task(
 
     let mut slot = Slot::new(port, slot_id, receiver);
     slot.init_device_slot(runner).await;
+    let device_descriptor = slot.get_device_descriptor().await;
+    info!("{:?}", device_descriptor);
 }
 
 // FIXME: Resolve this.
@@ -138,5 +144,9 @@ impl Slot {
             .await
             .address_device(self.context.input.phys_addr(), self.id)
             .await;
+    }
+
+    async fn get_device_descriptor(&mut self) -> PageBox<descriptor::Device> {
+        self.sender.get_device_descriptor().await
     }
 }

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::{
-    exchanger::command::Sender,
+    exchanger::command,
     structures::{
         context::Context,
         dcbaa::DeviceContextBaseAddressArray,
@@ -18,7 +18,7 @@ use resetter::Resetter;
 mod context;
 mod resetter;
 
-async fn task(mut port: Port, runner: Rc<LocalMutex<Sender>>) {
+async fn task(mut port: Port, runner: Rc<LocalMutex<command::Sender>>) {
     port.reset();
     port.init_context();
 
@@ -31,7 +31,7 @@ async fn task(mut port: Port, runner: Rc<LocalMutex<Sender>>) {
 // FIXME: Resolve this.
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_tasks(
-    command_runner: &Rc<LocalMutex<Sender>>,
+    command_runner: &Rc<LocalMutex<command::Sender>>,
     dcbaa: &Rc<RefCell<DeviceContextBaseAddressArray>>,
     registers: &Rc<RefCell<Registers>>,
     task_collection: &Rc<RefCell<task::Collection>>,
@@ -109,7 +109,7 @@ impl Slot {
         }
     }
 
-    async fn init_device_slot(&mut self, runner: Rc<LocalMutex<Sender>>) {
+    async fn init_device_slot(&mut self, runner: Rc<LocalMutex<command::Sender>>) {
         self.register_with_dcbaa();
         self.issue_address_device(runner).await;
     }
@@ -118,7 +118,7 @@ impl Slot {
         self.dcbaa.borrow_mut()[self.id.into()] = self.context.output_device.phys_addr();
     }
 
-    async fn issue_address_device(&mut self, runner: Rc<LocalMutex<Sender>>) {
+    async fn issue_address_device(&mut self, runner: Rc<LocalMutex<command::Sender>>) {
         runner
             .lock()
             .await

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -45,7 +45,7 @@ pub fn spawn_tasks(
     command_runner: &Rc<LocalMutex<command::Sender>>,
     dcbaa: &Rc<RefCell<DeviceContextBaseAddressArray>>,
     registers: &Rc<RefCell<Registers>>,
-    receiver: Rc<RefCell<Receiver>>,
+    receiver: &Rc<RefCell<Receiver>>,
     task_collection: &Rc<RefCell<task::Collection>>,
 ) {
     for i in 0..num_of_ports(&registers) {

--- a/kernel/src/device/pci/xhci/structures/descriptor.rs
+++ b/kernel/src/device/pci/xhci/structures/descriptor.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 // Temporary implementation.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Device([u8; 18]);

--- a/kernel/src/device/pci/xhci/structures/ring/event/trb/completion.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/event/trb/completion.rs
@@ -21,7 +21,7 @@ impl Completion {
     pub fn addr(&self) -> PhysAddr {
         match self {
             Self::Command(c) => c.trb_addr(),
-            Self::Transfer(t) => unimplemented!(),
+            Self::Transfer(t) => t.trb_addr(),
         }
     }
 }
@@ -57,4 +57,11 @@ impl CommandCompletion {
 add_trb!(TransferEvent);
 impl TransferEvent {
     const ID: u8 = 32;
+
+    fn trb_addr(&self) -> PhysAddr {
+        let l: u64 = self.0[0].into();
+        let u: u64 = self.0[1].into();
+
+        PhysAddr::new(u << 32 | l)
+    }
 }

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/mod.rs
@@ -45,7 +45,8 @@ impl Raw {
         trbs.iter().map(|t| self.enqueue(*t)).collect()
     }
 
-    fn enqueue(&mut self, trb: Trb) -> PhysAddr {
+    fn enqueue(&mut self, mut trb: Trb) -> PhysAddr {
+        trb.set_c(self.c);
         self.write_trb_on_memory(trb);
         let addr_to_trb = self.addr_to_enqueue_ptr();
         self.increment_enqueue_ptr();

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb/control.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb/control.rs
@@ -31,6 +31,14 @@ impl Control {
             false
         }
     }
+
+    pub fn set_cycle_bit(&mut self, c: CycleBit) {
+        match self {
+            Self::Setup(s) => s.set_cycle_bit(c),
+            Self::Data(d) => d.set_cycle_bit(c),
+            Self::Status(s) => s.set_cycle_bit(c),
+        }
+    }
 }
 impl From<Control> for [u32; 4] {
     fn from(c: Control) -> Self {

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb/control.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb/control.rs
@@ -67,7 +67,13 @@ impl SetupStage {
     }
 
     fn null() -> Self {
-        Self([0; 4])
+        let mut t = Self([0; 4]);
+        t.set_idt();
+        t
+    }
+
+    fn set_idt(&mut self) {
+        self.0[3].set_bit(6, true);
     }
 
     fn set_request_type(&mut self, t: u8) {

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
@@ -31,7 +31,7 @@ impl Trb {
 
     pub fn set_c(&mut self, c: CycleBit) {
         match self {
-            Self::Control(_) => unimplemented!(),
+            Self::Control(co) => co.set_cycle_bit(c),
             Self::Link(l) => l.set_cycle_bit(c),
         }
     }


### PR DESCRIPTION
- refactor: add `command::` prefix
- chore: `Slot` takes `sender`
- chore: implement `Debug` for `descriptor::Device`
- chore: fetch the device descriptor
- fix: forgot to set the Cycle bit
- fix: set IDT flag of the Setup TRB
- fix: implement `Completion::addr`
- chore: pass an argument by reference
- refactor: remove a redundant clone

bors r+
