### PR TITLE
Limit the size of functions

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,2 @@
 too-many-arguments-threshold = 3
+too-many-lines-threshold = 20

--- a/bootx64/src/fs/kernel/mod.rs
+++ b/bootx64/src/fs/kernel/mod.rs
@@ -3,7 +3,6 @@
 use super::root_dir;
 use common::constant::{KERNEL_ADDR, KERNEL_NAME};
 use core::{
-    cmp,
     convert::{TryFrom, TryInto},
     slice,
 };

--- a/bootx64/src/fs/kernel/mod.rs
+++ b/bootx64/src/fs/kernel/mod.rs
@@ -2,7 +2,11 @@
 
 use super::root_dir;
 use common::constant::{KERNEL_ADDR, KERNEL_NAME};
-use core::{cmp, convert::TryFrom, slice};
+use core::{
+    cmp,
+    convert::{TryFrom, TryInto},
+    slice,
+};
 use elf_rs::Elf;
 use os_units::Bytes;
 use uefi::{
@@ -50,10 +54,9 @@ pub fn fetch_entry_address_and_memory_size(addr: PhysAddr, bytes: Bytes) -> (Vir
         Elf::Elf64(elf) => {
             let entry_addr = VirtAddr::new(elf.header().entry_point());
             let mem_size = elf.program_header_iter().fold(Bytes::new(0), |acc, x| {
-                cmp::max(
-                    acc,
-                    Bytes::new(usize::try_from(x.ph.vaddr() + x.ph.memsz()).unwrap()),
-                )
+                acc.max(Bytes::new(
+                    (x.ph.vaddr() + x.ph.memsz()).try_into().unwrap(),
+                ))
             }) - Bytes::new(usize::try_from(KERNEL_ADDR.as_u64()).unwrap());
 
             info!("Entry point: {:?}", entry_addr);

--- a/bootx64/src/main.rs
+++ b/bootx64/src/main.rs
@@ -21,12 +21,7 @@ mod gop;
 mod mem;
 
 use common::{kernelboot, mem::reserved};
-use core::{
-    convert::{TryFrom, TryInto},
-    ptr,
-    ptr::NonNull,
-    slice,
-};
+use core::{convert::TryInto, ptr, ptr::NonNull, slice};
 use fs::kernel;
 use mem::{paging, stack};
 use uefi::{

--- a/bootx64/src/main.rs
+++ b/bootx64/src/main.rs
@@ -21,7 +21,12 @@ mod gop;
 mod mem;
 
 use common::{kernelboot, mem::reserved};
-use core::{convert::TryFrom, ptr, ptr::NonNull, slice};
+use core::{
+    convert::{TryFrom, TryInto},
+    ptr,
+    ptr::NonNull,
+    slice,
+};
 use fs::kernel;
 use mem::{paging, stack};
 use uefi::{
@@ -109,9 +114,7 @@ fn terminate_boot_services(image: Handle, system_table: SystemTable<Boot>) -> co
     for (index, descriptor) in descriptors_iter.enumerate() {
         unsafe {
             ptr::write(
-                memory_map_buf
-                    .as_ptr()
-                    .offset(isize::try_from(index).unwrap()),
+                memory_map_buf.as_ptr().offset(index.try_into().unwrap()),
                 *descriptor,
             );
         }

--- a/bootx64/src/main.rs
+++ b/bootx64/src/main.rs
@@ -105,7 +105,7 @@ fn terminate_boot_services(image: Handle, system_table: SystemTable<Boot>) -> co
         .expect("Failed to exit boot services")
         .unwrap();
 
-    let mut num_descriptors = 0;
+    let num_descriptors = descriptors_iter.len();
     for (index, descriptor) in descriptors_iter.enumerate() {
         unsafe {
             ptr::write(
@@ -113,8 +113,6 @@ fn terminate_boot_services(image: Handle, system_table: SystemTable<Boot>) -> co
                 *descriptor,
             );
         }
-
-        num_descriptors += 1;
     }
 
     common::mem::Map::new(memory_map_buf, num_descriptors)

--- a/kernel/src/graphics/screen/cursor.rs
+++ b/kernel/src/graphics/screen/cursor.rs
@@ -22,17 +22,7 @@ impl Cursor {
 
         layer::get_controller()
             .lock()
-            .edit_layer(id, |layer: &mut Layer| {
-                for y in 0..MOUSE_CURSOR_HEIGHT {
-                    for x in 0..MOUSE_CURSOR_WIDTH {
-                        layer[y][x] = match MOUSE_GRAPHIC[y][x] {
-                            '*' => Some(RGB8::new(0, 0, 0)),
-                            '0' => Some(RGB8::new(0xff, 0xff, 0xff)),
-                            _ => None,
-                        }
-                    }
-                }
-            })
+            .edit_layer(id, Self::init_layer)
             .expect("Layer of mouse cursor should be added.");
 
         Self {
@@ -49,6 +39,18 @@ impl Cursor {
             .lock()
             .slide_layer(self.id, self.coord.as_())
             .expect("Layer of mouse cursor should be added.");
+    }
+
+    fn init_layer(layer: &mut Layer) {
+        for y in 0..MOUSE_CURSOR_HEIGHT {
+            for x in 0..MOUSE_CURSOR_WIDTH {
+                layer[y][x] = match MOUSE_GRAPHIC[y][x] {
+                    '*' => Some(RGB8::new(0, 0, 0)),
+                    '0' => Some(RGB8::new(0xff, 0xff, 0xff)),
+                    _ => None,
+                }
+            }
+        }
     }
 
     fn fit_in_screen(&mut self) {

--- a/kernel/src/graphics/screen/desktop.rs
+++ b/kernel/src/graphics/screen/desktop.rs
@@ -10,7 +10,6 @@ pub struct Desktop {
     id: screen_layer::Id,
 }
 
-#[rustfmt::skip]
 impl Desktop {
     pub fn new() -> Self {
         let layer = Layer::new(Vec2::new(0, 0), Vram::resolution().as_());
@@ -19,6 +18,7 @@ impl Desktop {
         Self { id }
     }
 
+    #[allow(clippy::too_many_lines)]
     pub fn draw(&self) {
         let edit = |layer: &mut Layer| {
             let x_len = Vram::resolution().x;
@@ -36,22 +36,64 @@ impl Desktop {
                 }
             };
 
-            draw_desktop_part(RGB8::new(0x00,0x84,0x84), 0, 0, x_len - 1, y_len - 29);
-            draw_desktop_part(RGB8::new(0xC6,0xC6,0xC6), 0, y_len - 28, x_len - 1, y_len - 28);
-            draw_desktop_part(RGB8::new(0xFF,0xFF,0xFF), 0, y_len - 27, x_len - 1, y_len - 27);
-            draw_desktop_part(RGB8::new(0xC6,0xC6,0xC6), 0, y_len - 26, x_len - 1, y_len - 1);
+            draw_desktop_part(RGB8::new(0x00, 0x84, 0x84), 0, 0, x_len - 1, y_len - 29);
+            draw_desktop_part(
+                RGB8::new(0xC6, 0xC6, 0xC6),
+                0,
+                y_len - 28,
+                x_len - 1,
+                y_len - 28,
+            );
+            draw_desktop_part(
+                RGB8::new(0xFF, 0xFF, 0xFF),
+                0,
+                y_len - 27,
+                x_len - 1,
+                y_len - 27,
+            );
+            draw_desktop_part(
+                RGB8::new(0xC6, 0xC6, 0xC6),
+                0,
+                y_len - 26,
+                x_len - 1,
+                y_len - 1,
+            );
 
-            draw_desktop_part(RGB8::new(0xFF,0xFF,0xFF), 3, y_len - 24, 59, y_len - 24);
-            draw_desktop_part(RGB8::new(0xFF,0xFF,0xFF), 2, y_len - 24, 2, y_len - 4);
-            draw_desktop_part(RGB8::new(0x84,0x84,0x84), 3, y_len - 4, 59, y_len - 4);
-            draw_desktop_part(RGB8::new(0x84,0x84,0x84), 59, y_len - 23, 59, y_len - 5);
-            draw_desktop_part(RGB8::new(0x00,0x00,0x00), 2, y_len - 3, 59, y_len - 3);
-            draw_desktop_part(RGB8::new(0x00,0x00,0x00), 60, y_len - 24, 60, y_len - 3);
+            draw_desktop_part(RGB8::new(0xFF, 0xFF, 0xFF), 3, y_len - 24, 59, y_len - 24);
+            draw_desktop_part(RGB8::new(0xFF, 0xFF, 0xFF), 2, y_len - 24, 2, y_len - 4);
+            draw_desktop_part(RGB8::new(0x84, 0x84, 0x84), 3, y_len - 4, 59, y_len - 4);
+            draw_desktop_part(RGB8::new(0x84, 0x84, 0x84), 59, y_len - 23, 59, y_len - 5);
+            draw_desktop_part(RGB8::new(0x00, 0x00, 0x00), 2, y_len - 3, 59, y_len - 3);
+            draw_desktop_part(RGB8::new(0x00, 0x00, 0x00), 60, y_len - 24, 60, y_len - 3);
 
-            draw_desktop_part(RGB8::new(0x84,0x84,0x84), x_len - 47, y_len - 24, x_len - 4, y_len - 24);
-            draw_desktop_part(RGB8::new(0x84,0x84,0x84), x_len - 47, y_len - 23, x_len - 47, y_len - 4);
-            draw_desktop_part(RGB8::new(0xFF,0xFF,0xFF), x_len - 47, y_len - 3, x_len - 4, y_len - 3);
-            draw_desktop_part(RGB8::new(0xFF,0xFF,0xFF), x_len - 3, y_len - 24, x_len - 3, y_len - 3);
+            draw_desktop_part(
+                RGB8::new(0x84, 0x84, 0x84),
+                x_len - 47,
+                y_len - 24,
+                x_len - 4,
+                y_len - 24,
+            );
+            draw_desktop_part(
+                RGB8::new(0x84, 0x84, 0x84),
+                x_len - 47,
+                y_len - 23,
+                x_len - 47,
+                y_len - 4,
+            );
+            draw_desktop_part(
+                RGB8::new(0xFF, 0xFF, 0xFF),
+                x_len - 47,
+                y_len - 3,
+                x_len - 4,
+                y_len - 3,
+            );
+            draw_desktop_part(
+                RGB8::new(0xFF, 0xFF, 0xFF),
+                x_len - 3,
+                y_len - 24,
+                x_len - 3,
+                y_len - 3,
+            );
         };
 
         layer::get_controller()

--- a/kernel/src/graphics/screen/desktop.rs
+++ b/kernel/src/graphics/screen/desktop.rs
@@ -10,6 +10,7 @@ pub struct Desktop {
     id: screen_layer::Id,
 }
 
+#[rustfmt::skip]
 impl Desktop {
     pub fn new() -> Self {
         let layer = Layer::new(Vec2::new(0, 0), Vram::resolution().as_());
@@ -23,13 +24,7 @@ impl Desktop {
             let x_len = Vram::resolution().x;
             let y_len = Vram::resolution().y;
 
-            let mut draw_desktop_part = |color, x0, y0, x1, y1| {
-                let rgb = RGB8::new(
-                    u8::try_from((color >> 16) & 0xff).unwrap(),
-                    u8::try_from((color >> 8) & 0xff).unwrap(),
-                    u8::try_from(color & 0xff).unwrap(),
-                );
-
+            let mut draw_desktop_part = |rgb, x0, y0, x1, y1| {
                 for y in y0..y1 {
                     for x in x0..x1 {
                         layer[usize::try_from(y)
@@ -41,22 +36,22 @@ impl Desktop {
                 }
             };
 
-            draw_desktop_part(0x0000_8484, 0, 0, x_len - 1, y_len - 29);
-            draw_desktop_part(0x00C6_C6C6, 0, y_len - 28, x_len - 1, y_len - 28);
-            draw_desktop_part(0x00FF_FFFF, 0, y_len - 27, x_len - 1, y_len - 27);
-            draw_desktop_part(0x00C6_C6C6, 0, y_len - 26, x_len - 1, y_len - 1);
+            draw_desktop_part(RGB8::new(0x00,0x84,0x84), 0, 0, x_len - 1, y_len - 29);
+            draw_desktop_part(RGB8::new(0xC6,0xC6,0xC6), 0, y_len - 28, x_len - 1, y_len - 28);
+            draw_desktop_part(RGB8::new(0xFF,0xFF,0xFF), 0, y_len - 27, x_len - 1, y_len - 27);
+            draw_desktop_part(RGB8::new(0xC6,0xC6,0xC6), 0, y_len - 26, x_len - 1, y_len - 1);
 
-            draw_desktop_part(0x00FF_FFFF, 3, y_len - 24, 59, y_len - 24);
-            draw_desktop_part(0x00FF_FFFF, 2, y_len - 24, 2, y_len - 4);
-            draw_desktop_part(0x0084_8484, 3, y_len - 4, 59, y_len - 4);
-            draw_desktop_part(0x0084_8484, 59, y_len - 23, 59, y_len - 5);
-            draw_desktop_part(0x0000_0000, 2, y_len - 3, 59, y_len - 3);
-            draw_desktop_part(0x0000_0000, 60, y_len - 24, 60, y_len - 3);
+            draw_desktop_part(RGB8::new(0xFF,0xFF,0xFF), 3, y_len - 24, 59, y_len - 24);
+            draw_desktop_part(RGB8::new(0xFF,0xFF,0xFF), 2, y_len - 24, 2, y_len - 4);
+            draw_desktop_part(RGB8::new(0x84,0x84,0x84), 3, y_len - 4, 59, y_len - 4);
+            draw_desktop_part(RGB8::new(0x84,0x84,0x84), 59, y_len - 23, 59, y_len - 5);
+            draw_desktop_part(RGB8::new(0x00,0x00,0x00), 2, y_len - 3, 59, y_len - 3);
+            draw_desktop_part(RGB8::new(0x00,0x00,0x00), 60, y_len - 24, 60, y_len - 3);
 
-            draw_desktop_part(0x0084_8484, x_len - 47, y_len - 24, x_len - 4, y_len - 24);
-            draw_desktop_part(0x0084_8484, x_len - 47, y_len - 23, x_len - 47, y_len - 4);
-            draw_desktop_part(0x00FF_FFFF, x_len - 47, y_len - 3, x_len - 4, y_len - 3);
-            draw_desktop_part(0x00FF_FFFF, x_len - 3, y_len - 24, x_len - 3, y_len - 3);
+            draw_desktop_part(RGB8::new(0x84,0x84,0x84), x_len - 47, y_len - 24, x_len - 4, y_len - 24);
+            draw_desktop_part(RGB8::new(0x84,0x84,0x84), x_len - 47, y_len - 23, x_len - 47, y_len - 4);
+            draw_desktop_part(RGB8::new(0xFF,0xFF,0xFF), x_len - 47, y_len - 3, x_len - 4, y_len - 3);
+            draw_desktop_part(RGB8::new(0xFF,0xFF,0xFF), x_len - 3, y_len - 24, x_len - 3, y_len - 3);
         };
 
         layer::get_controller()

--- a/kernel/src/mem/accessor.rs
+++ b/kernel/src/mem/accessor.rs
@@ -105,15 +105,11 @@ impl<T: ?Sized> Accessor<T> {
         for i in 0..num_pages.as_usize() {
             let page = Page::<Size4KiB>::containing_address(virt + Size4KiB::SIZE * i as u64);
             let frame = PhysFrame::containing_address(start_frame_addr + Size4KiB::SIZE * i as u64);
+            let flag = PageTableFlags::PRESENT;
 
             unsafe {
                 PML4.lock()
-                    .map_to(
-                        page,
-                        frame,
-                        PageTableFlags::PRESENT,
-                        &mut *FRAME_MANAGER.lock(),
-                    )
+                    .map_to(page, frame, flag, &mut *FRAME_MANAGER.lock())
                     .unwrap()
                     .flush()
             }

--- a/kernel/src/mem/allocator/heap.rs
+++ b/kernel/src/mem/allocator/heap.rs
@@ -21,6 +21,11 @@ pub static ALLOCATOR: LockedHeap = LockedHeap::empty();
 // Using UEFI's `allocate_pages` doesn't work for allocating larger memory. It returns out of
 // resrouces.
 pub fn init(mem_map: &mut [boot::MemoryDescriptor]) {
+    alloc_for_heap(mem_map);
+    init_allocator();
+}
+
+fn alloc_for_heap(mem_map: &mut [boot::MemoryDescriptor]) {
     let mut temp_allocator = TemporaryFrameAllocator(mem_map);
     for i in 0..BYTES_KERNEL_HEAP.as_num_of_pages::<Size4KiB>().as_usize() {
         let frame = temp_allocator
@@ -36,7 +41,9 @@ pub fn init(mem_map: &mut [boot::MemoryDescriptor]) {
                 .flush();
         };
     }
+}
 
+fn init_allocator() {
     unsafe {
         ALLOCATOR.lock().init(
             usize::try_from(KERNEL_HEAP_ADDR.as_u64()).unwrap(),

--- a/kernel/src/mem/allocator/page_box.rs
+++ b/kernel/src/mem/allocator/page_box.rs
@@ -172,15 +172,11 @@ impl<T: ?Sized> PageBox<T> {
             let page =
                 Page::<Size4KiB>::from_start_address(virt_addr + Size4KiB::SIZE * i).unwrap();
             let frame = PhysFrame::from_start_address(phys_addr + Size4KiB::SIZE * i).unwrap();
+            let flags: PageTableFlags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
 
             unsafe {
                 PML4.lock()
-                    .map_to(
-                        page,
-                        frame,
-                        PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
-                        &mut *FRAME_MANAGER.lock(),
-                    )
+                    .map_to(page, frame, flags, &mut *FRAME_MANAGER.lock())
                     .unwrap()
                     .flush()
             }


### PR DESCRIPTION
- style: set the limitation of the function size
- refactor: introduce `flags` variable
- refactor: rename to `temp_allocator`
- refactor: split `init` into two functions
- refactor: introduce `flag` variable
- refactor: define `init_layer` method
- refactor: pass by `RGB8` type
- chore: allow too many lines of the method which draws the desktop

bors r+
