### PR TITLE
Enable endpoint

### DIFF
--- a/kernel/src/device/pci/xhci/exchanger/command.rs
+++ b/kernel/src/device/pci/xhci/exchanger/command.rs
@@ -36,6 +36,11 @@ impl Sender {
         self.issue_trb(t).await;
     }
 
+    pub async fn configure_endpoint(&mut self, context_addr: PhysAddr, slot_id: u8) {
+        let t = Trb::new_configure_endpoint(context_addr, slot_id);
+        self.issue_trb(t).await;
+    }
+
     async fn issue_trb(&mut self, t: Trb) -> Completion {
         let a = self.ring.borrow_mut().enqueue(t);
         self.register_with_receiver(a);

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -31,12 +31,14 @@ async fn task(
     let slot_id = runner.lock().await.enable_device_slot().await;
 
     let mut slot = Slot::new(port, slot_id, receiver);
-    slot.init_device_slot(runner).await;
+    slot.init_device_slot(runner.clone()).await;
     let device_descriptor = slot.get_device_descriptor().await;
     info!("{:?}", device_descriptor);
 
     let configuration_descriptor = slot.get_configuration_descriptors().await;
     info!("{:?}", configuration_descriptor);
+
+    slot.enable_endpoint(runner).await;
 }
 
 // FIXME: Resolve this.

--- a/kernel/src/device/pci/xhci/structures/context.rs
+++ b/kernel/src/device/pci/xhci/structures/context.rs
@@ -5,6 +5,7 @@ use crate::mem::allocator::page_box::PageBox;
 use bit_field::BitField;
 use bitfield::bitfield;
 use core::convert::{TryFrom, TryInto};
+use num_derive::FromPrimitive;
 use x86_64::PhysAddr;
 
 pub struct Context {
@@ -215,6 +216,13 @@ impl Endpoint {
     }
 }
 
+#[derive(FromPrimitive)]
 pub enum EndpointType {
+    IsochronousOut = 1,
+    BulkOut = 2,
+    InterruptOut = 3,
     Control = 4,
+    IsochronousIn = 5,
+    BulkIn = 6,
+    InterruptIn = 7,
 }

--- a/kernel/src/device/pci/xhci/structures/context.rs
+++ b/kernel/src/device/pci/xhci/structures/context.rs
@@ -90,7 +90,8 @@ impl InputWithControl64Bit {
 }
 
 pub trait InputControl {
-    fn set_aflag(&mut self, inde: usize);
+    fn set_aflag(&mut self, i: usize);
+    fn clear_aflag(&mut self, i: usize);
 }
 
 #[repr(transparent)]
@@ -105,6 +106,11 @@ impl InputControl for InputControl32Bit {
         assert!(index < 32);
         self.0[1] |= 1 << index;
     }
+
+    fn clear_aflag(&mut self, i: usize) {
+        assert!(i < 32);
+        self.0[1].set_bit(i, false);
+    }
 }
 
 #[repr(transparent)]
@@ -118,6 +124,11 @@ impl InputControl for InputControl64Bit {
     fn set_aflag(&mut self, index: usize) {
         assert!(index < 64);
         self.0[1] |= 1 << index;
+    }
+
+    fn clear_aflag(&mut self, i: usize) {
+        assert!(i < 64);
+        self.0[1].set_bit(i, false);
     }
 }
 

--- a/kernel/src/device/pci/xhci/structures/context.rs
+++ b/kernel/src/device/pci/xhci/structures/context.rs
@@ -124,7 +124,7 @@ impl InputControl for InputControl64Bit {
 pub struct Device {
     pub slot: Slot,
     pub ep_0: Endpoint,
-    ep_inout: [EndpointOutIn; 15],
+    pub ep_inout: [EndpointOutIn; 15],
 }
 impl Device {
     pub fn null() -> Self {
@@ -153,8 +153,8 @@ impl Slot {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct EndpointOutIn {
-    out: Endpoint,
-    input: Endpoint,
+    pub out: Endpoint,
+    pub input: Endpoint,
 }
 impl EndpointOutIn {
     fn null() -> Self {

--- a/kernel/src/device/pci/xhci/structures/descriptor.rs
+++ b/kernel/src/device/pci/xhci/structures/descriptor.rs
@@ -77,9 +77,9 @@ pub struct Endpoint {
     len: u8,
     descriptor_type: u8,
     pub endpoint_address: u8,
-    attributes: u8,
-    max_packet_size: u16,
-    interval: u8,
+    pub attributes: u8,
+    pub max_packet_size: u16,
+    pub interval: u8,
 }
 
 #[derive(FromPrimitive)]

--- a/kernel/src/device/pci/xhci/structures/descriptor.rs
+++ b/kernel/src/device/pci/xhci/structures/descriptor.rs
@@ -76,7 +76,7 @@ pub struct Interface {
 pub struct Endpoint {
     len: u8,
     descriptor_type: u8,
-    endpoint_address: u8,
+    pub endpoint_address: u8,
     attributes: u8,
     max_packet_size: u16,
     interval: u8,

--- a/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
@@ -84,3 +84,29 @@ impl AddressDevice {
         self.0[3].set_bits(24..=31, id.into());
     }
 }
+
+add_trb!(ConfigureEndpoint);
+impl ConfigureEndpoint {
+    const ID: u8 = 12;
+    pub fn new(context_addr: PhysAddr, slot_id: u8) -> Self {
+        let mut t = Self([0; 4]);
+        t.set_context_addr(context_addr);
+        t.set_slot_id(slot_id);
+        t.set_trb_type(Self::ID);
+        t
+    }
+
+    fn set_context_addr(&mut self, a: PhysAddr) {
+        assert!(a.is_aligned(16_u64));
+
+        let l = a.as_u64() & 0xffff_ffff;
+        let u = a.as_u64() >> 32;
+
+        self.0[0] = l.try_into().unwrap();
+        self.0[1] = u.try_into().unwrap();
+    }
+
+    fn set_slot_id(&mut self, id: u8) {
+        self.0[3].set_bits(24..=31, id.into());
+    }
+}

--- a/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
@@ -11,6 +11,7 @@ pub enum Trb {
     Link(Link),
     EnableSlot(EnableSlot),
     AddressDevice(AddressDevice),
+    ConfigureEndpoint(ConfigureEndpoint),
 }
 impl Trb {
     pub const SIZE: Bytes = Bytes::new(16);
@@ -32,6 +33,7 @@ impl Trb {
             Self::Link(l) => l.set_cycle_bit(c),
             Self::EnableSlot(e) => e.set_cycle_bit(c),
             Self::AddressDevice(a) => a.set_cycle_bit(c),
+            Self::ConfigureEndpoint(e) => e.set_cycle_bit(c),
         }
     }
 }
@@ -41,6 +43,7 @@ impl From<Trb> for [u32; 4] {
             Trb::Link(l) => l.0,
             Trb::EnableSlot(e) => e.0,
             Trb::AddressDevice(a) => a.0,
+            Trb::ConfigureEndpoint(c) => c.0,
         }
     }
 }

--- a/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
@@ -28,6 +28,10 @@ impl Trb {
         Self::AddressDevice(AddressDevice::new(input_context_addr, slot_id))
     }
 
+    pub fn new_configure_endpoint(context_addr: PhysAddr, slot_id: u8) -> Self {
+        Self::ConfigureEndpoint(ConfigureEndpoint::new(context_addr, slot_id))
+    }
+
     pub fn set_c(&mut self, c: CycleBit) {
         match self {
             Self::Link(l) => l.set_cycle_bit(c),


### PR DESCRIPTION
- chore: set A flag
- chore: add `pub`s
- chore: initialize contexts
- refactor: define `EndpointContextInitializer`
- chore: define `ConfigureEndpoint`
- chore: add `ConfigureEndpoint` as a variant
- chore: add `new_configure_endpoint`
- chore: define `configure_endpoint`
- fix: forgot to clear A1 bit

bors r+
