### PR TITLE
Initialize the default endpoint in `Slot` struct

### DIFF
--- a/kernel/src/device/pci/xhci/exchanger/transfer.rs
+++ b/kernel/src/device/pci/xhci/exchanger/transfer.rs
@@ -35,6 +35,10 @@ impl Sender {
         }
     }
 
+    pub fn ring_addr(&self) -> PhysAddr {
+        self.ring.phys_addr()
+    }
+
     pub async fn get_device_descriptor(&mut self) -> PageBox<descriptor::Device> {
         let b = PageBox::new(descriptor::Device::default());
         let (setup, data, status) =

--- a/kernel/src/device/pci/xhci/exchanger/transfer.rs
+++ b/kernel/src/device/pci/xhci/exchanger/transfer.rs
@@ -22,13 +22,9 @@ pub struct Sender {
     waker: Rc<RefCell<AtomicWaker>>,
 }
 impl Sender {
-    pub fn new(
-        ring: transfer::Ring,
-        receiver: Rc<RefCell<Receiver>>,
-        doorbell_writer: DoorbellWriter,
-    ) -> Self {
+    pub fn new(receiver: Rc<RefCell<Receiver>>, doorbell_writer: DoorbellWriter) -> Self {
         Self {
-            ring,
+            ring: transfer::Ring::new(),
             receiver,
             doorbell_writer,
             waker: Rc::new(RefCell::new(AtomicWaker::new())),

--- a/kernel/src/device/pci/xhci/exchanger/transfer.rs
+++ b/kernel/src/device/pci/xhci/exchanger/transfer.rs
@@ -52,6 +52,7 @@ impl Sender {
         let (setup, data, status) =
             Trb::new_get_descriptor(&b, DescTyIdx::new(descriptor::Ty::Configuration, 0));
         self.issue_trbs(&[setup, data, status]).await;
+        info!("Got TRBs");
         b
     }
 

--- a/kernel/src/device/pci/xhci/port/context.rs
+++ b/kernel/src/device/pci/xhci/port/context.rs
@@ -1,28 +1,19 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::device::pci::xhci::structures::{
-    context::{Context, EndpointType},
-    ring::{transfer, CycleBit},
-};
+use crate::device::pci::xhci::structures::context::Context;
 
 pub struct Initializer<'a> {
     context: &'a mut Context,
-    ring: &'a transfer::Ring,
     port_id: u8,
 }
 impl<'a> Initializer<'a> {
-    pub fn new(context: &'a mut Context, ring: &'a transfer::Ring, port_id: u8) -> Self {
-        Self {
-            context,
-            ring,
-            port_id,
-        }
+    pub fn new(context: &'a mut Context, port_id: u8) -> Self {
+        Self { context, port_id }
     }
 
     pub fn init(&mut self) {
         self.init_input_control();
         self.init_input_slot();
-        self.init_input_default_control_endpoint0();
     }
 
     fn init_input_control(&mut self) {
@@ -35,16 +26,5 @@ impl<'a> Initializer<'a> {
         let slot = &mut self.context.input.device_mut().slot;
         slot.set_context_entries(1);
         slot.set_root_hub_port_number(self.port_id);
-    }
-
-    fn init_input_default_control_endpoint0(&mut self) {
-        let ep_0 = &mut self.context.input.device_mut().ep_0;
-        ep_0.set_endpoint_type(EndpointType::Control);
-
-        // FIXME: Support other sppeds.
-        ep_0.set_max_packet_size(64);
-        ep_0.set_dequeue_ptr(self.ring.phys_addr());
-        ep_0.set_dequeue_cycle_state(CycleBit::new(true));
-        ep_0.set_error_count(3);
     }
 }

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -6,7 +6,6 @@ use super::{
         context::Context,
         dcbaa::DeviceContextBaseAddressArray,
         registers::{operational::PortRegisters, Registers},
-        ring::transfer::Ring as TransferRing,
     },
 };
 use crate::multitask::task::{self, Task};
@@ -32,6 +31,7 @@ async fn task(
 
     let mut slot = Slot::new(port, slot_id, receiver);
     slot.init(runner.clone()).await;
+    info!("Slot initialized");
     let mut eps = endpoint::Collection::new(slot, runner).await;
     eps.init().await;
     info!("Yahoo");
@@ -69,7 +69,6 @@ pub struct Port {
     registers: Rc<RefCell<Registers>>,
     index: u8,
     context: Context,
-    transfer_ring: TransferRing,
     dcbaa: Rc<RefCell<DeviceContextBaseAddressArray>>,
 }
 impl Port {
@@ -83,7 +82,6 @@ impl Port {
             index,
             context: Context::new(&registers.borrow()),
             dcbaa,
-            transfer_ring: TransferRing::new(),
         }
     }
 
@@ -96,7 +94,7 @@ impl Port {
     }
 
     fn init_context(&mut self) {
-        context::Initializer::new(&mut self.context, &self.transfer_ring, self.index).init();
+        context::Initializer::new(&mut self.context, self.index).init();
     }
 
     fn read_port_rg(&self) -> PortRegisters {

--- a/kernel/src/device/pci/xhci/port/slot/endpoint.rs
+++ b/kernel/src/device/pci/xhci/port/slot/endpoint.rs
@@ -74,14 +74,19 @@ pub struct Default {
     cx: Rc<RefCell<Context>>,
 }
 impl Default {
-    fn new(rcv: Rc<RefCell<Receiver>>, reg: Rc<RefCell<Registers>>, slot: &Slot) -> Self {
+    fn new(
+        rcv: Rc<RefCell<Receiver>>,
+        reg: Rc<RefCell<Registers>>,
+        slot_id: u8,
+        cx: Rc<RefCell<Context>>,
+    ) -> Self {
         Self {
             sender: transfer::Sender::new(
                 TransferRing::new(),
                 rcv,
-                DoorbellWriter::new(reg, slot.id),
+                DoorbellWriter::new(reg, slot_id),
             ),
-            cx: slot.context.clone(),
+            cx,
         }
     }
 

--- a/kernel/src/device/pci/xhci/port/slot/endpoint.rs
+++ b/kernel/src/device/pci/xhci/port/slot/endpoint.rs
@@ -7,7 +7,7 @@ use crate::{
             context::{self, Context},
             descriptor,
             registers::Registers,
-            ring::{transfer::Ring as TransferRing, CycleBit},
+            ring::CycleBit,
         },
     },
     mem::allocator::page_box::PageBox,
@@ -85,11 +85,7 @@ impl Default {
         cx: Rc<RefCell<Context>>,
     ) -> Self {
         Self {
-            sender: transfer::Sender::new(
-                TransferRing::new(),
-                rcv,
-                DoorbellWriter::new(reg, slot_id),
-            ),
+            sender: transfer::Sender::new(rcv, DoorbellWriter::new(reg, slot_id)),
             cx,
         }
     }

--- a/kernel/src/device/pci/xhci/port/slot/endpoint.rs
+++ b/kernel/src/device/pci/xhci/port/slot/endpoint.rs
@@ -11,6 +11,7 @@ use crate::device::pci::xhci::{
 };
 use alloc::{rc::Rc, vec::Vec};
 use bit_field::BitField;
+use context::EndpointType;
 use core::cell::RefCell;
 use futures_intrusive::sync::LocalMutex;
 use num_traits::FromPrimitive;
@@ -82,6 +83,18 @@ impl Default {
             ),
             cx: slot.context.clone(),
         }
+    }
+
+    fn init_context(&mut self) {
+        let mut cx = self.cx.borrow_mut();
+        let ep_0 = &mut cx.input.device_mut().ep_0;
+        ep_0.set_endpoint_type(EndpointType::Control);
+
+        // TODO: Support other speeds.
+        ep_0.set_max_packet_size(64);
+        ep_0.set_dequeue_ptr(self.sender.ring_addr());
+        ep_0.set_dequeue_cycle_state(CycleBit::new(true));
+        ep_0.set_error_count(3);
     }
 }
 

--- a/kernel/src/device/pci/xhci/port/slot/endpoint.rs
+++ b/kernel/src/device/pci/xhci/port/slot/endpoint.rs
@@ -78,16 +78,8 @@ pub struct Default {
     cx: Rc<RefCell<Context>>,
 }
 impl Default {
-    pub fn new(
-        rcv: Rc<RefCell<Receiver>>,
-        reg: Rc<RefCell<Registers>>,
-        slot_id: u8,
-        cx: Rc<RefCell<Context>>,
-    ) -> Self {
-        Self {
-            sender: transfer::Sender::new(rcv, DoorbellWriter::new(reg, slot_id)),
-            cx,
-        }
+    pub fn new(sender: transfer::Sender, cx: Rc<RefCell<Context>>) -> Self {
+        Self { sender, cx }
     }
 
     pub async fn get_device_descriptor(&mut self) -> PageBox<descriptor::Device> {

--- a/kernel/src/device/pci/xhci/port/slot/mod.rs
+++ b/kernel/src/device/pci/xhci/port/slot/mod.rs
@@ -3,7 +3,7 @@
 use super::{super::structures::descriptor::Descriptor, Port};
 use crate::{
     device::pci::xhci::{
-        exchanger::{command, receiver::Receiver},
+        exchanger::{command, receiver::Receiver, transfer},
         structures::{context::Context, dcbaa::DeviceContextBaseAddressArray, descriptor},
     },
     mem::allocator::page_box::PageBox,
@@ -12,6 +12,7 @@ use alloc::{rc::Rc, vec::Vec};
 use core::cell::RefCell;
 use endpoint::Endpoint;
 use futures_intrusive::sync::LocalMutex;
+use transfer::DoorbellWriter;
 
 pub mod endpoint;
 
@@ -28,7 +29,10 @@ impl Slot {
             id,
             dcbaa: port.dcbaa,
             cx: cx.clone(),
-            def_ep: endpoint::Default::new(receiver, port.registers, id, cx),
+            def_ep: endpoint::Default::new(
+                transfer::Sender::new(receiver, DoorbellWriter::new(port.registers, id)),
+                cx,
+            ),
         }
     }
 

--- a/kernel/src/device/pci/xhci/port/slot/mod.rs
+++ b/kernel/src/device/pci/xhci/port/slot/mod.rs
@@ -3,7 +3,7 @@
 use super::{super::structures::descriptor::Descriptor, Port};
 use crate::{
     device::pci::xhci::{
-        exchanger::{command, receiver::Receiver, transfer},
+        exchanger::{command, receiver::Receiver},
         structures::{context::Context, dcbaa::DeviceContextBaseAddressArray, descriptor},
     },
     mem::allocator::page_box::PageBox,
@@ -12,37 +12,34 @@ use alloc::{rc::Rc, vec::Vec};
 use core::cell::RefCell;
 use endpoint::Endpoint;
 use futures_intrusive::sync::LocalMutex;
-use transfer::DoorbellWriter;
 
 pub mod endpoint;
 
 pub struct Slot {
     id: u8,
-    sender: transfer::Sender,
     dcbaa: Rc<RefCell<DeviceContextBaseAddressArray>>,
-    context: Rc<RefCell<Context>>,
+    cx: Rc<RefCell<Context>>,
+    def_ep: endpoint::Default,
 }
 impl Slot {
     pub fn new(port: Port, id: u8, receiver: Rc<RefCell<Receiver>>) -> Self {
+        let cx = Rc::new(RefCell::new(port.context));
         Self {
             id,
-            sender: transfer::Sender::new(
-                port.transfer_ring,
-                receiver,
-                DoorbellWriter::new(port.registers, id),
-            ),
             dcbaa: port.dcbaa,
-            context: Rc::new(RefCell::new(port.context)),
+            cx: cx.clone(),
+            def_ep: endpoint::Default::new(receiver, port.registers, id, cx),
         }
     }
 
     pub async fn init(&mut self, runner: Rc<LocalMutex<command::Sender>>) {
+        self.init_default_ep();
         self.register_with_dcbaa();
         self.issue_address_device(runner).await;
     }
 
     pub async fn get_device_descriptor(&mut self) -> PageBox<descriptor::Device> {
-        self.sender.get_device_descriptor().await
+        self.def_ep.get_device_descriptor().await
     }
 
     pub async fn endpoints(&mut self) -> Vec<Endpoint> {
@@ -51,7 +48,7 @@ impl Slot {
 
         for d in ds {
             if let Descriptor::Endpoint(ep) = d {
-                eps.push(Endpoint::new(ep, self.context.clone()));
+                eps.push(Endpoint::new(ep, self.cx.clone()));
             }
         }
 
@@ -63,16 +60,20 @@ impl Slot {
         RawDescriptorParser::new(r).parse()
     }
 
+    fn init_default_ep(&mut self) {
+        self.def_ep.init_context();
+    }
+
     async fn get_raw_configuration_descriptors(&mut self) -> PageBox<[u8]> {
-        self.sender.get_configuration_descriptor().await
+        self.def_ep.get_raw_configuration_descriptors().await
     }
 
     fn register_with_dcbaa(&mut self) {
-        self.dcbaa.borrow_mut()[self.id.into()] = self.context.borrow().output_device.phys_addr();
+        self.dcbaa.borrow_mut()[self.id.into()] = self.cx.borrow().output_device.phys_addr();
     }
 
     async fn issue_address_device(&mut self, runner: Rc<LocalMutex<command::Sender>>) {
-        let cx_addr = self.context.borrow().input.phys_addr();
+        let cx_addr = self.cx.borrow().input.phys_addr();
         runner.lock().await.address_device(cx_addr, self.id).await;
     }
 }


### PR DESCRIPTION
- chore: define `endpoint::Default`
- chore: define `endpoint::Default::init_context`
- chore: `Default` does not take `slot`
- refactor: use `endpoint::Default`
- refactor: `transfer::Sender` no longer takes `ring`
- refactor: reduce the number of parameters of `endpoint::Default::new`

bors r+
