### PR TITLE
refactor: `Resetter` no longer takes `Rc<RefCell>` value

### DIFF
--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -90,7 +90,7 @@ impl Port {
     }
 
     fn reset(&mut self) {
-        Resetter::new(self.registers.clone(), self.index).reset();
+        Resetter::new(&mut self.registers.borrow_mut(), self.index).reset();
     }
 
     fn init_context(&mut self) {

--- a/kernel/src/device/pci/xhci/port/resetter.rs
+++ b/kernel/src/device/pci/xhci/port/resetter.rs
@@ -1,17 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use core::cell::RefCell;
-
-use alloc::rc::Rc;
-
 use crate::device::pci::xhci::structures::registers::Registers;
 
-pub struct Resetter {
-    registers: Rc<RefCell<Registers>>,
+pub struct Resetter<'a> {
+    registers: &'a mut Registers,
     slot: u8,
 }
-impl Resetter {
-    pub fn new(registers: Rc<RefCell<Registers>>, slot: u8) -> Self {
+impl<'a> Resetter<'a> {
+    pub fn new(registers: &'a mut Registers, slot: u8) -> Self {
         Self { registers, slot }
     }
 
@@ -21,12 +17,12 @@ impl Resetter {
     }
 
     fn start_resetting(&mut self) {
-        let r = &mut self.registers.borrow_mut().operational.port_registers;
+        let r = &mut self.registers.operational.port_registers;
         r.update((self.slot - 1).into(), |r| r.port_sc.set_port_reset(true))
     }
 
     fn wait_until_reset_is_completed(&self) {
-        let r = &self.registers.borrow().operational.port_registers;
+        let r = &self.registers.operational.port_registers;
         while !r.read((self.slot - 1).into()).port_sc.port_reset_changed() {}
     }
 }


### PR DESCRIPTION
No need to do that.

bors r+
