### PR TITLE
Add `sender` as a member of `Endpoint`

### DIFF
--- a/kernel/src/device/pci/xhci/exchanger/transfer.rs
+++ b/kernel/src/device/pci/xhci/exchanger/transfer.rs
@@ -95,6 +95,7 @@ impl Sender {
     }
 }
 
+#[derive(Clone)]
 pub struct DoorbellWriter {
     registers: Rc<RefCell<Registers>>,
     slot_id: u8,

--- a/kernel/src/device/pci/xhci/port/slot/endpoint.rs
+++ b/kernel/src/device/pci/xhci/port/slot/endpoint.rs
@@ -61,10 +61,15 @@ impl Collection {
 pub struct Endpoint {
     desc: descriptor::Endpoint,
     cx: Rc<RefCell<Context>>,
+    sender: transfer::Sender,
 }
 impl Endpoint {
-    pub fn new(desc: descriptor::Endpoint, cx: Rc<RefCell<Context>>) -> Self {
-        Self { desc, cx }
+    pub fn new(
+        desc: descriptor::Endpoint,
+        cx: Rc<RefCell<Context>>,
+        sender: transfer::Sender,
+    ) -> Self {
+        Self { desc, cx, sender }
     }
 
     pub fn init_context(&mut self) {

--- a/kernel/src/device/pci/xhci/port/slot/endpoint.rs
+++ b/kernel/src/device/pci/xhci/port/slot/endpoint.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use super::Slot;
 use crate::{
     device::pci::xhci::{
-        exchanger::{command, receiver::Receiver, transfer},
+        exchanger::{command, transfer},
         structures::{
             context::{self, Context},
             descriptor,
-            registers::Registers,
             ring::CycleBit,
         },
     },
@@ -18,9 +18,6 @@ use context::EndpointType;
 use core::cell::RefCell;
 use futures_intrusive::sync::LocalMutex;
 use num_traits::FromPrimitive;
-use transfer::DoorbellWriter;
-
-use super::Slot;
 
 pub struct Collection {
     def: Default,

--- a/kernel/src/device/pci/xhci/port/slot/endpoint.rs
+++ b/kernel/src/device/pci/xhci/port/slot/endpoint.rs
@@ -73,7 +73,7 @@ impl Endpoint {
     }
 
     pub fn init_context(&mut self) {
-        ContextInitializer::new(&self.desc, &mut self.cx.borrow_mut()).init();
+        ContextInitializer::new(&self.desc, &mut self.cx.borrow_mut(), &self.sender).init();
     }
 }
 
@@ -110,10 +110,19 @@ impl Default {
 struct ContextInitializer<'a> {
     ep: &'a descriptor::Endpoint,
     context: &'a mut Context,
+    sender: &'a transfer::Sender,
 }
 impl<'a> ContextInitializer<'a> {
-    fn new(ep: &'a descriptor::Endpoint, context: &'a mut Context) -> Self {
-        Self { ep, context }
+    fn new(
+        ep: &'a descriptor::Endpoint,
+        context: &'a mut Context,
+        sender: &'a transfer::Sender,
+    ) -> Self {
+        Self {
+            ep,
+            context,
+            sender,
+        }
     }
 
     fn init(&mut self) {
@@ -137,6 +146,7 @@ impl<'a> ContextInitializer<'a> {
         let ep_ty = self.ep_ty();
         let max_packet_size = self.ep.max_packet_size;
         let interval = self.ep.interval;
+        let ring_addr = self.sender.ring_addr();
 
         let c = self.ep_context();
         c.set_endpoint_type(ep_ty);
@@ -147,6 +157,7 @@ impl<'a> ContextInitializer<'a> {
         c.set_mult(0);
         c.set_error_count(3);
         c.set_interval(interval);
+        c.set_dequeue_ptr(ring_addr);
     }
 
     fn ep_context(&mut self) -> &mut context::Endpoint {

--- a/kernel/src/device/pci/xhci/port/slot/endpoint.rs
+++ b/kernel/src/device/pci/xhci/port/slot/endpoint.rs
@@ -23,6 +23,7 @@ use transfer::DoorbellWriter;
 use super::Slot;
 
 pub struct Collection {
+    def: Default,
     eps: Vec<Endpoint>,
     cx: Rc<RefCell<Context>>,
     cmd: Rc<LocalMutex<command::Sender>>,
@@ -33,6 +34,7 @@ impl Collection {
         let eps = slot.endpoints().await;
         info!("Endpoints collected");
         Self {
+            def: slot.def_ep,
             eps,
             cx: slot.cx,
             cmd,

--- a/kernel/src/device/pci/xhci/port/slot/mod.rs
+++ b/kernel/src/device/pci/xhci/port/slot/mod.rs
@@ -25,24 +25,22 @@ pub struct Slot {
     cx: Rc<RefCell<Context>>,
     def_ep: endpoint::Default,
     recv: Rc<RefCell<Receiver>>,
-    regs: Rc<RefCell<Registers>>,
+    dbl_writer: DoorbellWriter,
 }
 impl Slot {
     pub fn new(port: Port, id: u8, recv: Rc<RefCell<Receiver>>) -> Self {
         let cx = Rc::new(RefCell::new(port.context));
+        let dbl_writer = DoorbellWriter::new(port.registers.clone(), id);
         Self {
             id,
             dcbaa: port.dcbaa,
             cx: cx.clone(),
             def_ep: endpoint::Default::new(
-                transfer::Sender::new(
-                    recv.clone(),
-                    DoorbellWriter::new(port.registers.clone(), id),
-                ),
+                transfer::Sender::new(recv.clone(), dbl_writer.clone()),
                 cx,
             ),
             recv,
-            regs: port.registers,
+            dbl_writer,
         }
     }
 
@@ -65,10 +63,7 @@ impl Slot {
                 eps.push(Endpoint::new(
                     ep,
                     self.cx.clone(),
-                    transfer::Sender::new(
-                        self.recv.clone(),
-                        DoorbellWriter::new(self.regs.clone(), self.id),
-                    ),
+                    transfer::Sender::new(self.recv.clone(), self.dbl_writer.clone()),
                 ));
             }
         }


### PR DESCRIPTION
- chore: `endpoint::Collection` takes `def`
- refactor: remove unused imports
- chore: `Endpoint` has `sender`
- chore: clone `DoorbellWriter`
- chore: set the dequeue pointer of the Transfer Ring

bors r+
