### PR TITLE
Add `val` to `DoorbellWriter` as a member

### DIFF
--- a/kernel/src/device/pci/xhci/exchanger/transfer.rs
+++ b/kernel/src/device/pci/xhci/exchanger/transfer.rs
@@ -95,7 +95,6 @@ impl Sender {
     }
 }
 
-#[derive(Clone)]
 pub struct DoorbellWriter {
     registers: Rc<RefCell<Registers>>,
     slot_id: u8,

--- a/kernel/src/device/pci/xhci/exchanger/transfer.rs
+++ b/kernel/src/device/pci/xhci/exchanger/transfer.rs
@@ -75,7 +75,7 @@ impl Sender {
     }
 
     fn write_to_doorbell(&mut self) {
-        self.doorbell_writer.write(1);
+        self.doorbell_writer.write();
     }
 
     async fn get_trb(&mut self, ts: &[Trb], addrs: &[PhysAddr]) -> Vec<Option<Completion>> {
@@ -98,14 +98,19 @@ impl Sender {
 pub struct DoorbellWriter {
     registers: Rc<RefCell<Registers>>,
     slot_id: u8,
+    val: u32,
 }
 impl DoorbellWriter {
-    pub fn new(registers: Rc<RefCell<Registers>>, slot_id: u8) -> Self {
-        Self { registers, slot_id }
+    pub fn new(registers: Rc<RefCell<Registers>>, slot_id: u8, val: u32) -> Self {
+        Self {
+            registers,
+            slot_id,
+            val,
+        }
     }
 
-    pub fn write(&mut self, x: u32) {
+    pub fn write(&mut self) {
         let d = &mut self.registers.borrow_mut().doorbell_array;
-        d.update(self.slot_id.into(), |d| *d = x);
+        d.update(self.slot_id.into(), |d| *d = self.val);
     }
 }

--- a/kernel/src/device/pci/xhci/port/slot/mod.rs
+++ b/kernel/src/device/pci/xhci/port/slot/mod.rs
@@ -38,7 +38,7 @@ impl Slot {
             cx: cx.clone(),
             def_ep: endpoint::Default::new(transfer::Sender::new(recv.clone(), dbl_writer), cx),
             recv,
-            regs: port.registers.clone(),
+            regs: port.registers,
         }
     }
 

--- a/kernel/src/device/pci/xhci/port/slot/mod.rs
+++ b/kernel/src/device/pci/xhci/port/slot/mod.rs
@@ -27,7 +27,6 @@ pub struct Slot {
     def_ep: endpoint::Default,
     recv: Rc<RefCell<Receiver>>,
     regs: Rc<RefCell<Registers>>,
-    dbl_writer: DoorbellWriter,
 }
 impl Slot {
     pub fn new(port: Port, id: u8, recv: Rc<RefCell<Receiver>>) -> Self {
@@ -40,7 +39,6 @@ impl Slot {
             def_ep: endpoint::Default::new(transfer::Sender::new(recv.clone(), dbl_writer), cx),
             recv,
             regs: port.registers.clone(),
-            dbl_writer: DoorbellWriter::new(port.registers, id, 0),
         }
     }
 


### PR DESCRIPTION
- chore: remove `Clone` derivation
- chore: `DoorbellWriter` takes a value to write
- refactor: remove an unused member

bors r+
