### PR TITLE
Add a task mode "polling"

### DIFF
--- a/kernel/src/multitask/executor.rs
+++ b/kernel/src/multitask/executor.rs
@@ -76,7 +76,13 @@ impl Executor {
                 self.task_collection.borrow_mut().remove_task(id);
                 self.waker_collection.remove(&id);
             }
-            Poll::Pending => self.task_collection.borrow_mut().add_task_as_sleep(task),
+            Poll::Pending => {
+                if task.polling() {
+                    self.task_collection.borrow_mut().add_task_as_woken(task);
+                } else {
+                    self.task_collection.borrow_mut().add_task_as_sleep(task);
+                }
+            }
         }
     }
 }

--- a/kernel/src/multitask/task.rs
+++ b/kernel/src/multitask/task.rs
@@ -111,6 +111,7 @@ impl Id {
 pub struct Task {
     id: Id,
     future: Pin<Box<dyn Future<Output = ()>>>,
+    polling: bool,
 }
 
 impl Task {
@@ -118,6 +119,15 @@ impl Task {
         Self {
             id: Id::new(),
             future: Box::pin(future),
+            polling: false,
+        }
+    }
+
+    pub fn new_poll(future: impl Future<Output = ()> + 'static) -> Self {
+        Self {
+            id: Id::new(),
+            future: Box::pin(future),
+            polling: true,
         }
     }
 

--- a/kernel/src/multitask/task.rs
+++ b/kernel/src/multitask/task.rs
@@ -135,6 +135,10 @@ impl Task {
         self.future.as_mut().poll(context)
     }
 
+    pub fn polling(&self) -> bool {
+        self.polling
+    }
+
     pub(super) fn id(&self) -> Id {
         self.id
     }


### PR DESCRIPTION
- chore: add `polling` to `Task` as a member
- chore: let a task always woken
- refactor: let the Event ring task always wake

This task mode is used by tasks which need to poll something.

bors r+
