### PR TITLE
Implement syscall

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -93,6 +93,8 @@ fn initialization(boot_info: &mut kernelboot::Info) {
 
     timer::init(&acpi);
 
+    syscall::init();
+
     fs::ustar::list_files(INITRD_ADDR);
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -35,6 +35,7 @@ mod interrupt;
 mod mem;
 mod multitask;
 mod panic;
+mod syscall;
 mod tss;
 
 use common::{constant::INITRD_ADDR, kernelboot};

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -1,0 +1,1 @@
+// SPDX-License-Identifier: GPL-3.0-or-later

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -1,6 +1,6 @@
-use core::convert::TryInto;
-
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+use core::convert::TryInto;
 
 pub fn syscall() {
     info!("This is `syscall` function.");

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -21,7 +21,7 @@ fn enable() {
 }
 
 fn register() {
-    let addr = syscall as u64;
+    let addr = syscall as usize;
     let l: u32 = (addr & 0xffff_ffff).try_into().unwrap();
     let u: u32 = (addr >> 32).try_into().unwrap();
 

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -21,7 +21,7 @@ fn enable() {
 }
 
 fn register() {
-    let addr = syscall as usize;
+    let addr = wrapper as usize;
     let l: u32 = (addr & 0xffff_ffff).try_into().unwrap();
     let u: u32 = (addr >> 32).try_into().unwrap();
 
@@ -32,6 +32,29 @@ fn register() {
         mov ecx, 0xc0000082
         wrmsr
         ",in(reg) u,in(reg) l);
+    }
+}
+
+fn wrapper() {
+    unsafe {
+        asm!(
+            "
+        push rcx    # Save rip
+        push r11    # Save rflags
+        "
+        );
+    }
+
+    syscall();
+
+    unsafe {
+        asm!(
+            "
+        pop r11     # Restore rflags
+        pop rcx     # Restore rip
+        sysret
+        "
+        );
     }
 }
 

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -2,11 +2,25 @@
 
 use core::convert::TryInto;
 
-pub fn syscall() {
-    info!("This is `syscall` function.");
+pub fn init() {
+    enable();
+    register();
 }
 
-pub fn register() {
+fn enable() {
+    unsafe {
+        asm!(
+            "
+        mov ecx, 0xc0000080
+        rdmsr
+        or eax, 1
+        wrmsr
+        "
+        );
+    }
+}
+
+fn register() {
     let addr = syscall as u64;
     let l: u32 = (addr & 0xffff_ffff).try_into().unwrap();
     let u: u32 = (addr >> 32).try_into().unwrap();
@@ -19,4 +33,8 @@ pub fn register() {
         wrmsr
         ",in(reg) u,in(reg) l);
     }
+}
+
+fn syscall() {
+    info!("This is `syscall` function.");
 }

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -1,5 +1,22 @@
+use core::convert::TryInto;
+
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 pub fn syscall() {
     info!("This is `syscall` function.");
+}
+
+pub fn register() {
+    let addr = syscall as u64;
+    let l: u32 = (addr & 0xffff_ffff).try_into().unwrap();
+    let u: u32 = (addr >> 32).try_into().unwrap();
+
+    unsafe {
+        asm!("
+        mov edx, {:e}
+        mov eax, {:e}
+        mov ecx, 0xc0000082
+        wrmsr
+        ",in(reg) u,in(reg) l);
+    }
 }

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -1,1 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+pub fn syscall() {
+    info!("This is `syscall` function.");
+}


### PR DESCRIPTION
- chore: create `syscall.rs`
- chore: define `syscall` method
- chore: define `syscall::register`
- fix: license notation
- chore: define `syscall::init` method
- fix: cast a function pointer to `usize`
- chore: define a wrapper of `syscall`
- chore: initialize the settings of `syscall`

bors r+
