### PR TITLE
fix: kernel panic when a computer has lots of memory

### DIFF
--- a/kernel/src/graphics/screen/layer.rs
+++ b/kernel/src/graphics/screen/layer.rs
@@ -2,7 +2,7 @@
 
 use super::Vram;
 use conquer_once::spin::OnceCell;
-use core::convert::TryFrom;
+use core::convert::TryInto;
 use spinning_top::Spinlock;
 
 pub static CONTROLLER: OnceCell<Spinlock<screen_layer::Controller>> = OnceCell::uninit();
@@ -13,8 +13,8 @@ pub fn init() {
             Spinlock::new(unsafe {
                 screen_layer::Controller::new(
                     Vram::resolution().as_(),
-                    usize::try_from(Vram::bpp()).unwrap(),
-                    usize::try_from(Vram::ptr().as_u64()).unwrap(),
+                    Vram::bpp().try_into().unwrap(),
+                    Vram::ptr().as_u64().try_into().unwrap(),
                 )
             })
         })

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #![no_std]
+#![feature(int_bits_const)]
 #![feature(async_closure)]
 #![feature(alloc_error_handler)]
 #![feature(min_const_generics)]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -70,14 +70,14 @@ fn initialization(boot_info: &mut kernelboot::Info) {
 
     heap::init(boot_info.mem_map_mut());
 
-    FrameManager::init(boot_info.mem_map_mut());
-
     layer::init();
 
     screen::log::init().unwrap();
 
     let desktop = Desktop::new();
     desktop.draw();
+
+    FrameManager::init(boot_info.mem_map_mut());
 
     info!("Hello Ramen OS!");
     info!("Vram information: {}", Vram::display());
@@ -118,4 +118,20 @@ fn run_tasks() -> ! {
     // If you change the value `0xf4` and `33`, don't forget to change the correspond values in
     // `Makefile`!
     qemu_exit::X86::new(0xf4, 33).exit_success();
+}
+
+fn draw_white(boot_info: &mut kernelboot::Info) {
+    use core::convert::TryFrom;
+    let v = boot_info.vram();
+    for y in 0..v.resolution().y {
+        for x in 0..v.resolution().x {
+            unsafe {
+                core::ptr::write(
+                    (v.phys_ptr().as_u64() + u64::try_from(y * v.resolution().x + x).unwrap())
+                        as *mut u8,
+                    0xff,
+                );
+            }
+        }
+    }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -119,19 +119,3 @@ fn run_tasks() -> ! {
     // `Makefile`!
     qemu_exit::X86::new(0xf4, 33).exit_success();
 }
-
-fn draw_white(boot_info: &mut kernelboot::Info) {
-    use core::convert::TryFrom;
-    let v = boot_info.vram();
-    for y in 0..v.resolution().y {
-        for x in 0..v.resolution().x {
-            unsafe {
-                core::ptr::write(
-                    (v.phys_ptr().as_u64() + u64::try_from(y * v.resolution().x + x).unwrap())
-                        as *mut u8,
-                    0xff,
-                );
-            }
-        }
-    }
-}

--- a/kernel/src/mem/allocator/phys.rs
+++ b/kernel/src/mem/allocator/phys.rs
@@ -2,13 +2,14 @@
 
 use crate::mem::paging;
 use alloc::collections::vec_deque::VecDeque;
+use bit_field::BitField;
 use conquer_once::spin::Lazy;
-use core::convert::TryFrom;
+use core::convert::{TryFrom, TryInto};
 use os_units::NumOfPages;
 use spinning_top::Spinlock;
 use uefi::table::boot::{self, MemoryType};
 use x86_64::{
-    structures::paging::{FrameAllocator, FrameDeallocator, PageSize, PhysFrame, Size4KiB},
+    structures::paging::{FrameAllocator, FrameDeallocator, PhysFrame, Size4KiB},
     PhysAddr,
 };
 
@@ -59,11 +60,22 @@ impl FrameManager {
     }
 
     fn init_for_descriptor(&mut self, descriptor: &boot::MemoryDescriptor) {
-        for i in 0..descriptor.page_count {
-            let addr = PhysAddr::new(descriptor.phys_start + Size4KiB::SIZE * i);
-            let frames = Frames::new(addr, NumOfPages::new(1), true);
+        let mut offset = NumOfPages::<Size4KiB>::new(0);
 
-            self.0.push_back(frames);
+        // By reversing the range, bigger memory chanks come first.
+        // This will make it faster to search a small amount of memory.
+        for i in (0..u64::BITS).rev() {
+            if descriptor.page_count.get_bit(i.try_into().unwrap()) {
+                let addr = PhysAddr::new(
+                    descriptor.phys_start + u64::try_from(offset.as_bytes().as_usize()).unwrap(),
+                );
+                let pages = NumOfPages::new(2_usize.pow(i));
+                let frames = Frames::new(addr, pages, true);
+
+                self.0.push_back(frames);
+
+                offset += pages;
+            }
         }
     }
 

--- a/kernel/src/mem/allocator/phys.rs
+++ b/kernel/src/mem/allocator/phys.rs
@@ -86,7 +86,7 @@ impl FrameManager {
     }
 
     fn merge_all_nodes(&mut self) {
-        // By reversing the range, bit chunks of memory will go to the back of list.
+        // By reversing the range, bigger memory chanks come first.
         // This will make it faster to search a small amount of memory.
         for i in (0..self.0.len()).rev() {
             if self.mergeable(i) {


### PR DESCRIPTION
- refactor: use `try_into`
- chore: initialize desktop and log first
- fix: grammer
- refactor: remove a debug function
- fix: panic if a computer has lots of memory

bors r+
