### PR TITLE
fix: no timer interruptions happen

### DIFF
--- a/kernel/src/device/pci/ahci/registers/generic.rs
+++ b/kernel/src/device/pci/ahci/registers/generic.rs
@@ -15,10 +15,10 @@ impl Generic {
     /// SAFETY: This method is unsafe because if `abar` is not the valid AHCI base address, this
     /// method can violate memory safety.
     pub unsafe fn new(abar: AchiBaseAddr) -> Self {
-        let cap = Accessor::new(abar.into(), Bytes::new(0x00));
-        let ghc = Accessor::new(abar.into(), Bytes::new(0x04));
-        let pi = Accessor::new(abar.into(), Bytes::new(0x0c));
-        let bohc = Accessor::new(abar.into(), Bytes::new(0x28));
+        let cap = Accessor::user(abar.into(), Bytes::new(0x00));
+        let ghc = Accessor::user(abar.into(), Bytes::new(0x04));
+        let pi = Accessor::user(abar.into(), Bytes::new(0x0c));
+        let bohc = Accessor::user(abar.into(), Bytes::new(0x28));
 
         Self { cap, ghc, pi, bohc }
     }

--- a/kernel/src/device/pci/ahci/registers/port.rs
+++ b/kernel/src/device/pci/ahci/registers/port.rs
@@ -39,7 +39,7 @@ impl Registers {
 
         macro_rules! new_accessor {
             ($offset:expr) => {
-                Accessor::new(base_addr, Bytes::new($offset))
+                Accessor::user(base_addr, Bytes::new($offset))
             };
         }
 

--- a/kernel/src/device/pci/xhci/structures/registers/capability.rs
+++ b/kernel/src/device/pci/xhci/structures/registers/capability.rs
@@ -18,12 +18,12 @@ impl Capability {
     /// SAFETY: This method is unsafe because if `mmio_base` is not the valid MMIO base address, it
     /// can violate memory safety.
     pub unsafe fn new(mmio_base: PhysAddr) -> Self {
-        let cap_length = Accessor::new(mmio_base, Bytes::new(0));
-        let hcs_params_1 = Accessor::new(mmio_base, Bytes::new(0x04));
-        let hcs_params_2 = Accessor::new(mmio_base, Bytes::new(0x08));
-        let hc_cp_params_1 = Accessor::new(mmio_base, Bytes::new(0x10));
-        let db_off = Accessor::new(mmio_base, Bytes::new(0x14));
-        let rts_off = Accessor::new(mmio_base, Bytes::new(0x18));
+        let cap_length = Accessor::user(mmio_base, Bytes::new(0));
+        let hcs_params_1 = Accessor::user(mmio_base, Bytes::new(0x04));
+        let hcs_params_2 = Accessor::user(mmio_base, Bytes::new(0x08));
+        let hc_cp_params_1 = Accessor::user(mmio_base, Bytes::new(0x10));
+        let db_off = Accessor::user(mmio_base, Bytes::new(0x14));
+        let rts_off = Accessor::user(mmio_base, Bytes::new(0x18));
 
         Self {
             cap_length,

--- a/kernel/src/device/pci/xhci/structures/registers/doorbell.rs
+++ b/kernel/src/device/pci/xhci/structures/registers/doorbell.rs
@@ -10,7 +10,7 @@ const NUM_OF_REGISTERS: usize = 256;
 pub struct Array(Accessor<[u32]>);
 impl Array {
     pub fn new(mmio_base: PhysAddr, db_off: u32) -> Self {
-        Self(Accessor::new_slice(
+        Self(Accessor::user_slice(
             mmio_base,
             Bytes::new(db_off.try_into().unwrap()),
             NUM_OF_REGISTERS,

--- a/kernel/src/device/pci/xhci/structures/registers/doorbell.rs
+++ b/kernel/src/device/pci/xhci/structures/registers/doorbell.rs
@@ -9,7 +9,8 @@ const NUM_OF_REGISTERS: usize = 256;
 
 pub struct Array(Accessor<[u32]>);
 impl Array {
-    pub fn new(mmio_base: PhysAddr, db_off: u32) -> Self {
+    /// Safety: `mmio_base` must be a valid address to the top of the doorbell registers.
+    pub unsafe fn new(mmio_base: PhysAddr, db_off: u32) -> Self {
         Self(Accessor::user_slice(
             mmio_base,
             Bytes::new(db_off.try_into().unwrap()),

--- a/kernel/src/device/pci/xhci/structures/registers/operational.rs
+++ b/kernel/src/device/pci/xhci/structures/registers/operational.rs
@@ -21,12 +21,12 @@ impl Operational {
     pub unsafe fn new(mmio_base: PhysAddr, capabilities: &Capability) -> Self {
         let operational_base = mmio_base + capabilities.cap_length.read().get();
 
-        let usb_cmd = Accessor::new(operational_base, Bytes::new(0x00));
-        let usb_sts = Accessor::new(operational_base, Bytes::new(0x04));
-        let crcr = Accessor::new(operational_base, Bytes::new(0x18));
-        let dcbaap = Accessor::new(operational_base, Bytes::new(0x30));
-        let config = Accessor::new(operational_base, Bytes::new(0x38));
-        let port_registers = Accessor::new_slice(
+        let usb_cmd = Accessor::user(operational_base, Bytes::new(0x00));
+        let usb_sts = Accessor::user(operational_base, Bytes::new(0x04));
+        let crcr = Accessor::user(operational_base, Bytes::new(0x18));
+        let dcbaap = Accessor::user(operational_base, Bytes::new(0x30));
+        let config = Accessor::user(operational_base, Bytes::new(0x38));
+        let port_registers = Accessor::user_slice(
             operational_base,
             Bytes::new(0x400),
             capabilities.hcs_params_1.read().max_ports().into(),

--- a/kernel/src/device/pci/xhci/structures/registers/runtime.rs
+++ b/kernel/src/device/pci/xhci/structures/registers/runtime.rs
@@ -15,9 +15,9 @@ impl<'a> Runtime {
     /// `runtime_register_space_offset` is not a valid value, it can violate memory safety.
     pub unsafe fn new(mmio_base: PhysAddr, runtime_register_space_offset: usize) -> Self {
         let runtime_base = mmio_base + runtime_register_space_offset;
-        let erst_sz = Accessor::new(runtime_base, Bytes::new(0x28));
-        let erst_ba = Accessor::new(runtime_base, Bytes::new(0x30));
-        let erd_p = Accessor::new(runtime_base, Bytes::new(0x38));
+        let erst_sz = Accessor::user(runtime_base, Bytes::new(0x28));
+        let erst_ba = Accessor::user(runtime_base, Bytes::new(0x30));
+        let erd_p = Accessor::user(runtime_base, Bytes::new(0x38));
 
         Self {
             erst_sz,

--- a/kernel/src/device/pci/xhci/structures/registers/usb_legacy_support_capability.rs
+++ b/kernel/src/device/pci/xhci/structures/registers/usb_legacy_support_capability.rs
@@ -21,7 +21,7 @@ impl UsbLegacySupportCapability {
             .xhci_extended_capabilities_pointer();
         debug!("xECP: {}", xecp);
         let base = mmio_base + ((xecp as usize) << 2);
-        let usb_leg_sup = Accessor::<UsbLegacySupportCapabilityRegister>::new(base, Bytes::new(0));
+        let usb_leg_sup = Accessor::<UsbLegacySupportCapabilityRegister>::user(base, Bytes::new(0));
 
         if usb_leg_sup.read().id() == 1 {
             Some(Self { usb_leg_sup })

--- a/kernel/src/interrupt/apic/io.rs
+++ b/kernel/src/interrupt/apic/io.rs
@@ -9,7 +9,7 @@ use acpi::{platform::IoApic, AcpiTables, InterruptModel};
 use bit_field::BitField;
 use core::convert::TryInto;
 use os_units::Bytes;
-use x86_64::PhysAddr;
+use x86_64::{instructions::interrupts, PhysAddr};
 
 /// Currently this OS does not support multiple I/O APIC.
 
@@ -25,12 +25,14 @@ impl Registers {
     ///
     /// There is no need to create an instance of `IoApic` manually, but because it is possible as
     /// the all fields of the struct are public, this method is unsafe.
+    ///
+    /// This method must be called in the kernel privilege.
     unsafe fn new(io_apics: &[IoApic]) -> Self {
         let io_apic_base = PhysAddr::new(io_apics[0].address.into());
 
         Self {
-            addr: Accessor::user(io_apic_base, Bytes::new(0)),
-            data: Accessor::user(io_apic_base, Bytes::new(0x10)),
+            addr: Accessor::kernel(io_apic_base, Bytes::new(0)),
+            data: Accessor::kernel(io_apic_base, Bytes::new(0x10)),
         }
     }
 
@@ -149,7 +151,9 @@ pub fn init(table: &AcpiTables<allocator::acpi::Mapper>) {
         init_ps2_keyboard(&mut registers, id);
         init_ps2_mouse(&mut registers, id);
     }
-    syscall::enable_interrupt();
+
+    // Here the operation is in the kernel mode. `syscall` must not be called.
+    interrupts::enable();
 }
 
 fn init_ps2_keyboard(r: &mut Registers, apic_id: u8) {

--- a/kernel/src/interrupt/apic/io.rs
+++ b/kernel/src/interrupt/apic/io.rs
@@ -29,8 +29,8 @@ impl Registers {
         let io_apic_base = PhysAddr::new(io_apics[0].address.into());
 
         Self {
-            addr: Accessor::new(io_apic_base, Bytes::new(0)),
-            data: Accessor::new(io_apic_base, Bytes::new(0x10)),
+            addr: Accessor::user(io_apic_base, Bytes::new(0)),
+            data: Accessor::user(io_apic_base, Bytes::new(0x10)),
         }
     }
 

--- a/kernel/src/interrupt/apic/io.rs
+++ b/kernel/src/interrupt/apic/io.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::pic;
-use crate::{
-    mem::{accessor::Accessor, allocator},
-    syscall,
-};
+use crate::mem::{accessor::Accessor, allocator};
 use acpi::{platform::IoApic, AcpiTables, InterruptModel};
 use bit_field::BitField;
 use core::convert::TryInto;

--- a/kernel/src/interrupt/apic/local.rs
+++ b/kernel/src/interrupt/apic/local.rs
@@ -10,6 +10,6 @@ const REGISTER_BASE: PhysAddr = PhysAddr::new_truncate(0xfee0_0000);
 pub fn end_of_interrupt() {
     // SAFETY: This operation is safe because `REGISTER_BASE` is the valid address to the Local APIC
     // registers.
-    let mut r = unsafe { Accessor::<u32>::user(REGISTER_BASE, Bytes::new(0xb0)) };
+    let mut r = unsafe { Accessor::<u32>::kernel(REGISTER_BASE, Bytes::new(0xb0)) };
     r.write(0);
 }

--- a/kernel/src/interrupt/apic/local.rs
+++ b/kernel/src/interrupt/apic/local.rs
@@ -10,6 +10,6 @@ const REGISTER_BASE: PhysAddr = PhysAddr::new_truncate(0xfee0_0000);
 pub fn end_of_interrupt() {
     // SAFETY: This operation is safe because `REGISTER_BASE` is the valid address to the Local APIC
     // registers.
-    let mut r = unsafe { Accessor::<u32>::new(REGISTER_BASE, Bytes::new(0xb0)) };
+    let mut r = unsafe { Accessor::<u32>::user(REGISTER_BASE, Bytes::new(0xb0)) };
     r.write(0);
 }

--- a/kernel/src/interrupt/apic/pic.rs
+++ b/kernel/src/interrupt/apic/pic.rs
@@ -1,24 +1,24 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::syscall;
+use x86_64::instructions::port::PortWriteOnly;
 
-const MASTER_CMD: u16 = 0x20;
-const MASTER_DATA: u16 = 0x21;
+const MASTER_CMD: PortWriteOnly<u8> = PortWriteOnly::new(0x20);
+const MASTER_DATA: PortWriteOnly<u8> = PortWriteOnly::new(0x21);
 
-const SLAVE_CMD: u16 = 0xa0;
-const SLAVE_DATA: u16 = 0xa0;
+const SLAVE_CMD: PortWriteOnly<u8> = PortWriteOnly::new(0xa0);
+const SLAVE_DATA: PortWriteOnly<u8> = PortWriteOnly::new(0xa0);
 
-const MASTER_ICW1: u16 = MASTER_CMD;
-const SLAVE_ICW1: u16 = SLAVE_CMD;
+const MASTER_ICW1: PortWriteOnly<u8> = MASTER_CMD;
+const SLAVE_ICW1: PortWriteOnly<u8> = SLAVE_CMD;
 
-const MASTER_ICW2: u16 = MASTER_DATA;
-const SLAVE_ICW2: u16 = SLAVE_DATA;
+const MASTER_ICW2: PortWriteOnly<u8> = MASTER_DATA;
+const SLAVE_ICW2: PortWriteOnly<u8> = SLAVE_DATA;
 
-const MASTER_ICW3: u16 = MASTER_DATA;
-const SLAVE_ICW3: u16 = SLAVE_DATA;
+const MASTER_ICW3: PortWriteOnly<u8> = MASTER_DATA;
+const SLAVE_ICW3: PortWriteOnly<u8> = SLAVE_DATA;
 
-const MASTER_ICW4: u16 = MASTER_DATA;
-const SLAVE_ICW4: u16 = SLAVE_DATA;
+const MASTER_ICW4: PortWriteOnly<u8> = MASTER_DATA;
+const SLAVE_ICW4: PortWriteOnly<u8> = SLAVE_DATA;
 
 pub fn disable() {
     pic_init_mode();
@@ -29,36 +29,51 @@ pub fn disable() {
 }
 
 fn pic_init_mode() {
+    let mut m = MASTER_ICW1;
+    let mut s = SLAVE_ICW1;
+
     unsafe {
-        syscall::outb(MASTER_ICW1, 0x11);
-        syscall::outb(SLAVE_ICW1, 0x11);
+        m.write(0x11_u8);
+        s.write(0x11_u8);
     }
 }
 
 fn remap_pic() {
+    let mut m = MASTER_ICW2;
+    let mut s = SLAVE_ICW2;
+
     unsafe {
-        syscall::outb(MASTER_ICW2, 0x20);
-        syscall::outb(SLAVE_ICW2, 0x28);
+        m.write(0x20_u8);
+        s.write(0x28_u8);
     }
 }
 
 fn set_slave_offset() {
+    let mut m = MASTER_ICW3;
+    let mut s = SLAVE_ICW3;
+
     unsafe {
-        syscall::outb(MASTER_ICW3, 4);
-        syscall::outb(SLAVE_ICW3, 2);
+        m.write(4_u8);
+        s.write(2_u8);
     }
 }
 
 fn nonbuffer_mode() {
+    let mut m = MASTER_ICW4;
+    let mut s = SLAVE_ICW4;
+
     unsafe {
-        syscall::outb(MASTER_ICW4, 1);
-        syscall::outb(SLAVE_ICW4, 1);
+        m.write(1_u8);
+        s.write(1_u8);
     }
 }
 
 fn mask_pic() {
+    let mut m = MASTER_DATA;
+    let mut s = SLAVE_DATA;
+
     unsafe {
-        syscall::outb(MASTER_DATA, 0xFF);
-        syscall::outb(SLAVE_DATA, 0xFF);
+        m.write(0xFF_u8);
+        s.write(0xFF_u8);
     }
 }

--- a/kernel/src/interrupt/timer.rs
+++ b/kernel/src/interrupt/timer.rs
@@ -5,10 +5,7 @@ use core::convert::TryInto;
 use os_units::Bytes;
 use x86_64::{instructions::port::PortReadOnly, PhysAddr};
 
-use crate::{
-    mem::{accessor::Accessor, allocator},
-    syscall,
-};
+use crate::mem::{accessor::Accessor, allocator};
 
 const LVT_TIMER: PhysAddr = PhysAddr::new_truncate(0xfee0_0320);
 const INITIAL_COUNT: PhysAddr = PhysAddr::new_truncate(0xfee0_0380);

--- a/kernel/src/interrupt/timer.rs
+++ b/kernel/src/interrupt/timer.rs
@@ -32,10 +32,10 @@ struct LocalApic {
 impl LocalApic {
     fn new(table: &AcpiTables<allocator::acpi::Mapper>) -> Self {
         // SAFETY: These operations are safe because the addresses are the correct ones.
-        let lvt_timer = unsafe { Accessor::<u32>::new(LVT_TIMER, Bytes::new(0)) };
-        let initial_count = unsafe { Accessor::<u32>::new(INITIAL_COUNT, Bytes::new(0)) };
-        let current_count = unsafe { Accessor::<u32>::new(CURRENT_COUNT, Bytes::new(0)) };
-        let divide_config = unsafe { Accessor::<u32>::new(DIVIDE_CONFIG, Bytes::new(0)) };
+        let lvt_timer = unsafe { Accessor::<u32>::user(LVT_TIMER, Bytes::new(0)) };
+        let initial_count = unsafe { Accessor::<u32>::user(INITIAL_COUNT, Bytes::new(0)) };
+        let current_count = unsafe { Accessor::<u32>::user(CURRENT_COUNT, Bytes::new(0)) };
+        let divide_config = unsafe { Accessor::<u32>::user(DIVIDE_CONFIG, Bytes::new(0)) };
         let pm = AcpiPm::new(table);
 
         Self {
@@ -150,7 +150,7 @@ impl MemoryReader {
         let b = table.platform_info().unwrap().pm_timer.unwrap().base;
         Self {
             // SAFETY: This operation is safe as the address is generated from `AcpiTables`.
-            addr: unsafe { Accessor::new(PhysAddr::new(b.address), Bytes::new(0)) },
+            addr: unsafe { Accessor::user(PhysAddr::new(b.address), Bytes::new(0)) },
         }
     }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -78,6 +78,12 @@ fn initialize_in_kernel_mode(boot_info: &mut kernelboot::Info) {
 
     // This function unmaps all user memory, which needs the kernel privilege.
     FrameManager::init(boot_info.mem_map_mut());
+
+    let acpi = unsafe { acpi::get(boot_info.rsdp()) };
+
+    apic::io::init(&acpi);
+
+    timer::init(&acpi);
 }
 
 fn initialize_in_user_mode(boot_info: &mut kernelboot::Info) {
@@ -95,12 +101,6 @@ fn initialize_in_user_mode(boot_info: &mut kernelboot::Info) {
 
     info!("Hello Ramen OS!");
     info!("Vram information: {}", Vram::display());
-
-    let acpi = unsafe { acpi::get(boot_info.rsdp()) };
-
-    apic::io::init(&acpi);
-
-    timer::init(&acpi);
 
     fs::ustar::list_files(INITRD_ADDR);
 }

--- a/kernel/src/mem/accessor.rs
+++ b/kernel/src/mem/accessor.rs
@@ -59,10 +59,6 @@ impl<T> Accessor<T> {
 }
 
 impl<T> Accessor<[T]> {
-    pub fn kernel_slice(phys_base: PhysAddr, offset: Bytes, len: usize) -> Self {
-        Self::new_slice(phys_base, offset, len, Mappers::kernel())
-    }
-
     pub fn user_slice(phys_base: PhysAddr, offset: Bytes, len: usize) -> Self {
         Self::new_slice(phys_base, offset, len, Mappers::user())
     }

--- a/kernel/src/mem/accessor.rs
+++ b/kernel/src/mem/accessor.rs
@@ -10,19 +10,33 @@ pub struct Accessor<T: ?Sized> {
     virt: VirtAddr,
     bytes: Bytes, // The size of `T` is not always computable. Thus save the bytes of objects.
     _marker: PhantomData<T>,
+    mappers: Mappers,
 }
 impl<T> Accessor<T> {
     /// SAFETY: This method is unsafe because it can create multiple mutable references to the same
     /// object.
-    pub unsafe fn new(phys_base: PhysAddr, offset: Bytes) -> Self {
+    pub unsafe fn kernel(phys_base: PhysAddr, offset: Bytes) -> Self {
+        Self::new(phys_base, offset, Mappers::kernel())
+    }
+
+    /// SAFETY: This method is unsafe because it can create multiple mutable references to the same
+    /// object.
+    pub unsafe fn user(phys_base: PhysAddr, offset: Bytes) -> Self {
+        Self::new(phys_base, offset, Mappers::user())
+    }
+
+    /// SAFETY: This method is unsafe because it can create multiple mutable references to the same
+    /// object.
+    unsafe fn new(phys_base: PhysAddr, offset: Bytes, mappers: Mappers) -> Self {
         let phys_base = phys_base + offset.as_usize();
         let bytes = Bytes::new(mem::size_of::<T>());
-        let virt = syscall::map_pages(phys_base, bytes);
+        let virt = mappers.map(phys_base, bytes);
 
         Self {
             virt,
             bytes,
             _marker: PhantomData,
+            mappers,
         }
     }
 
@@ -45,17 +59,26 @@ impl<T> Accessor<T> {
 }
 
 impl<T> Accessor<[T]> {
+    pub fn kernel_slice(phys_base: PhysAddr, offset: Bytes, len: usize) -> Self {
+        Self::new_slice(phys_base, offset, len, Mappers::kernel())
+    }
+
+    pub fn user_slice(phys_base: PhysAddr, offset: Bytes, len: usize) -> Self {
+        Self::new_slice(phys_base, offset, len, Mappers::user())
+    }
+
     /// SAFETY: This method is unsafe because it can create multiple mutable references to the same
     /// object.
-    pub fn new_slice(phys_base: PhysAddr, offset: Bytes, len: usize) -> Self {
+    fn new_slice(phys_base: PhysAddr, offset: Bytes, len: usize, mappers: Mappers) -> Self {
         let phys_base = phys_base + offset.as_usize();
         let bytes = Bytes::new(mem::size_of::<T>() * len);
-        let virt = syscall::map_pages(phys_base, bytes);
+        let virt = mappers.map(phys_base, bytes);
 
         Self {
             virt,
             bytes,
             _marker: PhantomData,
+            mappers,
         }
     }
 
@@ -89,6 +112,37 @@ impl<T> Accessor<[T]> {
 
 impl<T: ?Sized> Drop for Accessor<T> {
     fn drop(&mut self) {
-        syscall::unmap_pages(self.virt, self.bytes);
+        self.mappers.unmap(self.virt, self.bytes);
+    }
+}
+
+type Mapper = fn(PhysAddr, Bytes) -> VirtAddr;
+type Unmapper = fn(VirtAddr, Bytes);
+
+struct Mappers {
+    mapper: Mapper,
+    unmapper: Unmapper,
+}
+impl Mappers {
+    fn kernel() -> Self {
+        Self {
+            mapper: super::map_pages,
+            unmapper: super::unmap_pages,
+        }
+    }
+
+    fn user() -> Self {
+        Self {
+            mapper: syscall::map_pages,
+            unmapper: syscall::unmap_pages,
+        }
+    }
+
+    fn map(&self, p: PhysAddr, b: Bytes) -> VirtAddr {
+        (self.mapper)(p, b)
+    }
+
+    fn unmap(&self, v: VirtAddr, b: Bytes) {
+        (self.unmapper)(v, b)
     }
 }

--- a/kernel/src/mem/accessor.rs
+++ b/kernel/src/mem/accessor.rs
@@ -16,19 +16,19 @@ impl<T> Accessor<T> {
     /// SAFETY: This method is unsafe because it can create multiple mutable references to the same
     /// object.
     pub unsafe fn kernel(phys_base: PhysAddr, offset: Bytes) -> Self {
-        Self::new(phys_base, offset, Mappers::kernel())
+        Self::new(EffectiveAddr::new(phys_base, offset), Mappers::kernel())
     }
 
     /// SAFETY: This method is unsafe because it can create multiple mutable references to the same
     /// object.
     pub unsafe fn user(phys_base: PhysAddr, offset: Bytes) -> Self {
-        Self::new(phys_base, offset, Mappers::user())
+        Self::new(EffectiveAddr::new(phys_base, offset), Mappers::user())
     }
 
     /// SAFETY: This method is unsafe because it can create multiple mutable references to the same
     /// object.
-    unsafe fn new(phys_base: PhysAddr, offset: Bytes, mappers: Mappers) -> Self {
-        let phys_base = phys_base + offset.as_usize();
+    unsafe fn new(effective: EffectiveAddr, mappers: Mappers) -> Self {
+        let phys_base = effective.calculate();
         let bytes = Bytes::new(mem::size_of::<T>());
         let virt = mappers.map(phys_base, bytes);
 
@@ -62,7 +62,7 @@ impl<T> Accessor<[T]> {
     /// # Safety: This method is unsafe because it can create multiple mutable references to the
     /// same object.
     pub unsafe fn user_slice(phys_base: PhysAddr, offset: Bytes, len: usize) -> Self {
-        Self::new_slice(phys_base, offset, len, Mappers::user())
+        Self::new_slice(EffectiveAddr::new(phys_base, offset), len, Mappers::user())
     }
 
     pub fn read(&self, index: usize) -> T {
@@ -86,8 +86,8 @@ impl<T> Accessor<[T]> {
 
     /// SAFETY: This method is unsafe because it can create multiple mutable references to the same
     /// object.
-    fn new_slice(phys_base: PhysAddr, offset: Bytes, len: usize, mappers: Mappers) -> Self {
-        let phys_base = phys_base + offset.as_usize();
+    fn new_slice(effective: EffectiveAddr, len: usize, mappers: Mappers) -> Self {
+        let phys_base = effective.calculate();
         let bytes = Bytes::new(mem::size_of::<T>() * len);
         let virt = mappers.map(phys_base, bytes);
 
@@ -111,6 +111,20 @@ impl<T> Accessor<[T]> {
 impl<T: ?Sized> Drop for Accessor<T> {
     fn drop(&mut self) {
         self.mappers.unmap(self.virt, self.bytes);
+    }
+}
+
+struct EffectiveAddr {
+    base: PhysAddr,
+    offset: Bytes,
+}
+impl EffectiveAddr {
+    fn new(base: PhysAddr, offset: Bytes) -> Self {
+        Self { base, offset }
+    }
+
+    fn calculate(&self) -> PhysAddr {
+        self.base + self.offset.as_usize()
     }
 }
 

--- a/kernel/src/mem/accessor.rs
+++ b/kernel/src/mem/accessor.rs
@@ -16,18 +16,18 @@ impl<T> Accessor<T> {
     /// SAFETY: This method is unsafe because it can create multiple mutable references to the same
     /// object.
     pub unsafe fn kernel(phys_base: PhysAddr, offset: Bytes) -> Self {
-        Self::new(EffectiveAddr::new(phys_base, offset), Mappers::kernel())
+        Self::new(&EffectiveAddr::new(phys_base, offset), Mappers::kernel())
     }
 
     /// SAFETY: This method is unsafe because it can create multiple mutable references to the same
     /// object.
     pub unsafe fn user(phys_base: PhysAddr, offset: Bytes) -> Self {
-        Self::new(EffectiveAddr::new(phys_base, offset), Mappers::user())
+        Self::new(&EffectiveAddr::new(phys_base, offset), Mappers::user())
     }
 
     /// SAFETY: This method is unsafe because it can create multiple mutable references to the same
     /// object.
-    unsafe fn new(effective: EffectiveAddr, mappers: Mappers) -> Self {
+    unsafe fn new(effective: &EffectiveAddr, mappers: Mappers) -> Self {
         let phys_base = effective.calculate();
         let bytes = Bytes::new(mem::size_of::<T>());
         let virt = mappers.map(phys_base, bytes);
@@ -62,7 +62,7 @@ impl<T> Accessor<[T]> {
     /// # Safety: This method is unsafe because it can create multiple mutable references to the
     /// same object.
     pub unsafe fn user_slice(phys_base: PhysAddr, offset: Bytes, len: usize) -> Self {
-        Self::new_slice(EffectiveAddr::new(phys_base, offset), len, Mappers::user())
+        Self::new_slice(&EffectiveAddr::new(phys_base, offset), len, Mappers::user())
     }
 
     pub fn read(&self, index: usize) -> T {
@@ -86,7 +86,7 @@ impl<T> Accessor<[T]> {
 
     /// SAFETY: This method is unsafe because it can create multiple mutable references to the same
     /// object.
-    fn new_slice(effective: EffectiveAddr, len: usize, mappers: Mappers) -> Self {
+    fn new_slice(effective: &EffectiveAddr, len: usize, mappers: Mappers) -> Self {
         let phys_base = effective.calculate();
         let bytes = Bytes::new(mem::size_of::<T>() * len);
         let virt = mappers.map(phys_base, bytes);

--- a/kernel/src/mem/accessor.rs
+++ b/kernel/src/mem/accessor.rs
@@ -59,7 +59,9 @@ impl<T> Accessor<T> {
 }
 
 impl<T> Accessor<[T]> {
-    pub fn user_slice(phys_base: PhysAddr, offset: Bytes, len: usize) -> Self {
+    /// # Safety: This method is unsafe because it can create multiple mutable references to the
+    /// same object.
+    pub unsafe fn user_slice(phys_base: PhysAddr, offset: Bytes, len: usize) -> Self {
         Self::new_slice(phys_base, offset, len, Mappers::user())
     }
 

--- a/kernel/src/mem/allocator/acpi.rs
+++ b/kernel/src/mem/allocator/acpi.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::{mem, syscall};
+use crate::mem;
 use acpi::{AcpiHandler, PhysicalMapping};
 use core::{convert::TryInto, ptr::NonNull};
 use os_units::Bytes;

--- a/kernel/src/mem/allocator/acpi.rs
+++ b/kernel/src/mem/allocator/acpi.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::syscall;
+use crate::{mem, syscall};
 use acpi::{AcpiHandler, PhysicalMapping};
 use core::{convert::TryInto, ptr::NonNull};
 use os_units::Bytes;
@@ -12,7 +12,10 @@ impl AcpiHandler for Mapper {
     unsafe fn map_physical_region<U>(&self, p_addr: usize, sz: usize) -> PhysicalMapping<Self, U> {
         let p = PhysAddr::new(p_addr.try_into().unwrap());
         let bytes = Bytes::new(sz);
-        let virt = syscall::map_pages(p, bytes);
+
+        // To call this method in the kernel mode, which is necessary to access APIC registers,
+        // call `crate::mem::map_pages`, not the system call one.
+        let virt = mem::map_pages(p, bytes);
 
         PhysicalMapping {
             physical_start: p_addr,
@@ -26,6 +29,6 @@ impl AcpiHandler for Mapper {
     fn unmap_physical_region<T>(&self, region: &PhysicalMapping<Self, T>) {
         let virt = VirtAddr::new(region.virtual_start.as_ptr() as u64);
         let bytes = Bytes::new(region.region_length);
-        syscall::unmap_pages(virt, bytes)
+        mem::unmap_pages(virt, bytes)
     }
 }

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -21,12 +21,6 @@ pub fn init() {
     register();
 }
 
-/// SAFETY: This function is unsafe because writing a value to I/O port may have side effects which
-/// violate memory safety.
-pub unsafe fn outb(port: u16, value: u8) {
-    general_syscall(Syscalls::Outb, port.into(), value.into());
-}
-
 /// SAFETY: This function is unsafe because reading a value from I/O port may have side effects which violate memory safety.
 pub unsafe fn inl(port: u16) -> u32 {
     general_syscall(Syscalls::Inl, port.into(), 0)


### PR DESCRIPTION
- chore: separate `user` and `kernel` accessor
- Revert "chore: rewrite with `inb` and `outb`"
- fix: no timer interruptions happen

Fixes: #522 

bors r+
