### PR TITLE
refactor: define `Spawner`

### DIFF
--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -30,7 +30,7 @@ pub async fn task() {
 
     let (event_ring, runner, command_completion_receiver) = init();
 
-    port::spawn_tasks(&runner, &command_completion_receiver);
+    port::spawn_tasks(runner.clone(), command_completion_receiver.clone());
 
     multitask::add(Task::new_poll(event::task(
         event_ring,

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -106,7 +106,7 @@ pub fn spawn_tasks(
     command_runner: &Arc<Futurelock<command::Sender>>,
     receiver: &Arc<Spinlock<Receiver>>,
 ) {
-    let ports_num = num_of_ports();
+    let ports_num = max_num();
     for i in 0..ports_num {
         let port = Port::new(i + 1);
         if port.connected() {
@@ -119,7 +119,7 @@ pub fn spawn_tasks(
     }
 }
 
-fn num_of_ports() -> u8 {
+fn max_num() -> u8 {
     super::handle_registers(|r| {
         let params1 = r.capability.hcs_params_1.read();
         params1.max_ports()

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -22,6 +22,7 @@ mod context;
 mod endpoint;
 mod resetter;
 mod slot;
+mod spawner;
 
 static CURRENT_RESET_PORT: Lazy<Spinlock<ResetPort>> =
     Lazy::new(|| Spinlock::new(ResetPort::new()));

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -103,11 +103,8 @@ async fn init_port_and_slot(
     endpoint::Collection::new(slot, runner).await
 }
 
-pub fn spawn_tasks(
-    command_runner: Arc<Futurelock<command::Sender>>,
-    receiver: Arc<Spinlock<Receiver>>,
-) {
-    let s = Spawner::new(command_runner, receiver);
+pub fn spawn_tasks(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Receiver>>) {
+    let s = Spawner::new(sender, receiver);
     s.scan_all_ports_and_spawn();
 }
 

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -1,0 +1,1 @@
+// SPDX-License-Identifier: GPL-3.0-or-later

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use alloc::sync::Arc;
+use multitask::task::Task;
 use spinning_top::Spinlock;
 
 use crate::{
     device::pci::xhci::exchanger::{command, receiver::Receiver},
-    Futurelock,
+    multitask, Futurelock,
 };
+
+use super::Port;
 
 struct Spawner {
     sender: Arc<Futurelock<command::Sender>>,
@@ -15,5 +18,14 @@ struct Spawner {
 impl Spawner {
     fn new(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Receiver>>) -> Self {
         Self { sender, receiver }
+    }
+
+    fn spawn(&self, port_idx: u8) {
+        let p = Port::new(port_idx);
+        multitask::add(Task::new(super::task(
+            p,
+            self.sender.clone(),
+            self.receiver.clone(),
+        )));
     }
 }

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -26,7 +26,7 @@ impl Spawner {
     pub fn scan_all_ports_and_spawn(&self) {
         let n = super::max_num();
         for i in 0..n {
-            let _ = self.try_spawn(i);
+            let _ = self.try_spawn(i + 1);
         }
     }
 

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -20,12 +20,20 @@ impl Spawner {
         Self { sender, receiver }
     }
 
-    fn spawn(&self, port_idx: u8) {
+    fn try_spawn(&self, port_idx: u8) -> Result<(), PortNotConnected> {
         let p = Port::new(port_idx);
-        multitask::add(Task::new(super::task(
-            p,
-            self.sender.clone(),
-            self.receiver.clone(),
-        )));
+        if p.connected() {
+            multitask::add(Task::new(super::task(
+                p,
+                self.sender.clone(),
+                self.receiver.clone(),
+            )));
+            Ok(())
+        } else {
+            Err(PortNotConnected)
+        }
     }
 }
+
+#[derive(Debug)]
+struct PortNotConnected;

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -20,6 +20,13 @@ impl Spawner {
         Self { sender, receiver }
     }
 
+    fn scan_all_ports_and_spawn(&self) {
+        let n = super::max_num();
+        for i in 0..n {
+            let _ = self.try_spawn(i);
+        }
+    }
+
     fn try_spawn(&self, port_idx: u8) -> Result<(), PortNotConnected> {
         let p = Port::new(port_idx);
         if p.connected() {

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -23,15 +23,19 @@ impl Spawner {
     fn try_spawn(&self, port_idx: u8) -> Result<(), PortNotConnected> {
         let p = Port::new(port_idx);
         if p.connected() {
-            multitask::add(Task::new(super::task(
-                p,
-                self.sender.clone(),
-                self.receiver.clone(),
-            )));
+            self.spawn(p);
             Ok(())
         } else {
             Err(PortNotConnected)
         }
+    }
+
+    fn spawn(&self, p: Port) {
+        multitask::add(Task::new(super::task(
+            p,
+            self.sender.clone(),
+            self.receiver.clone(),
+        )));
     }
 }
 

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -1,1 +1,19 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+use alloc::sync::Arc;
+use spinning_top::Spinlock;
+
+use crate::{
+    device::pci::xhci::exchanger::{command, receiver::Receiver},
+    Futurelock,
+};
+
+struct Spawner {
+    sender: Arc<Futurelock<command::Sender>>,
+    receiver: Arc<Spinlock<Receiver>>,
+}
+impl Spawner {
+    fn new(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Receiver>>) -> Self {
+        Self { sender, receiver }
+    }
+}

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -11,16 +11,19 @@ use crate::{
 
 use super::Port;
 
-struct Spawner {
+pub struct Spawner {
     sender: Arc<Futurelock<command::Sender>>,
     receiver: Arc<Spinlock<Receiver>>,
 }
 impl Spawner {
-    fn new(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Receiver>>) -> Self {
+    pub fn new(
+        sender: Arc<Futurelock<command::Sender>>,
+        receiver: Arc<Spinlock<Receiver>>,
+    ) -> Self {
         Self { sender, receiver }
     }
 
-    fn scan_all_ports_and_spawn(&self) {
+    pub fn scan_all_ports_and_spawn(&self) {
         let n = super::max_num();
         for i in 0..n {
             let _ = self.try_spawn(i);


### PR DESCRIPTION
- chore: create `spawner.rs`
- chore: define `Spawner` struct
- chore: define `Spawner::spawn`
- refactor: rename to `max_num`
- chore: rename to `try_spawn`
- chore: define `spawn` method
- chore: define `scan_all_ports_and_spawn`
- chore: make a struct and methods public
- fix: wrong port number was specified
- refactor: rewrite with `Spawner`
- refactor: rename to `sender`
