### PR TITLE
chore: do not spawn a port task if a task for it is already spawned

### DIFF
--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -58,6 +58,10 @@ impl Spawner {
     }
 }
 
+fn spawned(p: &Port) -> bool {
+    SPAWN_STATUS.lock()[usize::from(p.index)]
+}
+
 fn mark_as_spawned(p: &Port) {
     SPAWN_STATUS.lock()[usize::from(p.index)] = true;
 }

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -45,6 +45,7 @@ impl Spawner {
     }
 
     fn spawn(&self, p: Port) {
+        mark_as_spawned(&p);
         self.add_task_for_port(p);
     }
 

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -36,7 +36,7 @@ impl Spawner {
 
     fn try_spawn(&self, port_idx: u8) -> Result<(), PortNotConnected> {
         let p = Port::new(port_idx);
-        if p.connected() {
+        if spawnable(&p) {
             self.spawn(p);
             Ok(())
         } else {

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec, vec::Vec};
+use conquer_once::spin::Lazy;
 use multitask::task::Task;
 use spinning_top::Spinlock;
 
@@ -8,6 +9,9 @@ use crate::{
     device::pci::xhci::exchanger::{command, receiver::Receiver},
     multitask, Futurelock,
 };
+
+static SPAWN_STATUS: Lazy<Spinlock<Vec<bool>>> =
+    Lazy::new(|| Spinlock::new(vec![false; super::max_num().into()]));
 
 use super::Port;
 

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -58,6 +58,10 @@ impl Spawner {
     }
 }
 
+fn spawnable(p: &Port) -> bool {
+    p.connected() && !spawned(p)
+}
+
 fn spawned(p: &Port) -> bool {
     SPAWN_STATUS.lock()[usize::from(p.index)]
 }

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -57,5 +57,9 @@ impl Spawner {
     }
 }
 
+fn mark_as_spawned(p: &Port) {
+    SPAWN_STATUS.lock()[usize::from(p.index)] = true;
+}
+
 #[derive(Debug)]
 struct PortNotConnected;

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -45,6 +45,10 @@ impl Spawner {
     }
 
     fn spawn(&self, p: Port) {
+        self.add_task_for_port(p);
+    }
+
+    fn add_task_for_port(&self, p: Port) {
         multitask::add(Task::new(super::task(
             p,
             self.sender.clone(),


### PR DESCRIPTION
- chore: define `SPAWN_STATUS`
- chore: define `add_task_for_port` method
- chore: define `mark_as_spawned`
- chore: mark a port as spawn
- chore: define `spawned` method
- chore: define `spawnable` function
- chore: rewrite the conditional expression with `spawnable`

After resetting, the Port Status Change TRB is issued. This commit prevents to create a new task for the port in response to the TRB.
