### PR TITLE
refactor: provide functions to spawn tasks

### DIFF
--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -104,6 +104,7 @@ async fn init_port_and_slot(
 }
 
 pub fn spawn_tasks(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Receiver>>) {
+    spawner::init(sender.clone(), receiver.clone());
     let s = Spawner::new(sender, receiver);
     s.scan_all_ports_and_spawn();
 }

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -15,7 +15,6 @@ use conquer_once::spin::Lazy;
 use futures_util::task::AtomicWaker;
 use resetter::Resetter;
 use slot::Slot;
-use spawner::Spawner;
 use spinning_top::Spinlock;
 
 mod class_driver;
@@ -105,8 +104,7 @@ async fn init_port_and_slot(
 
 pub fn spawn_tasks(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Receiver>>) {
     spawner::init(sender.clone(), receiver.clone());
-    let s = Spawner::new(sender, receiver);
-    s.scan_all_ports_and_spawn();
+    spawner::spawn_all_connected_ports();
 }
 
 fn max_num() -> u8 {

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -103,7 +103,7 @@ async fn init_port_and_slot(
 }
 
 pub fn spawn_tasks(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Receiver>>) {
-    spawner::init(sender.clone(), receiver.clone());
+    spawner::init(sender, receiver);
     spawner::spawn_all_connected_ports();
 }
 

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -27,19 +27,16 @@ pub fn spawn_all_connected_ports() {
     s.spawn_all_connected_ports();
 }
 
-pub struct Spawner {
+struct Spawner {
     sender: Arc<Futurelock<command::Sender>>,
     receiver: Arc<Spinlock<Receiver>>,
 }
 impl Spawner {
-    pub fn new(
-        sender: Arc<Futurelock<command::Sender>>,
-        receiver: Arc<Spinlock<Receiver>>,
-    ) -> Self {
+    fn new(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Receiver>>) -> Self {
         Self { sender, receiver }
     }
 
-    pub fn spawn_all_connected_ports(&self) {
+    fn spawn_all_connected_ports(&self) {
         let n = super::max_num();
         for i in 0..n {
             let _ = self.try_spawn(i + 1);

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -24,7 +24,7 @@ pub fn init(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Rec
 
 pub fn spawn_all_connected_ports() {
     let s = SPAWNER.try_get().expect("SPAWNER is not initialized.");
-    s.scan_all_ports_and_spawn();
+    s.spawn_all_connected_ports();
 }
 
 pub struct Spawner {
@@ -39,7 +39,7 @@ impl Spawner {
         Self { sender, receiver }
     }
 
-    pub fn scan_all_ports_and_spawn(&self) {
+    pub fn spawn_all_connected_ports(&self) {
         let n = super::max_num();
         for i in 0..n {
             let _ = self.try_spawn(i + 1);

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -16,7 +16,7 @@ static SPAWNER: OnceCell<Spawner> = OnceCell::uninit();
 
 use super::Port;
 
-fn init(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Receiver>>) {
+pub fn init(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Receiver>>) {
     SPAWNER
         .try_init_once(|| Spawner::new(sender, receiver))
         .expect("SPAWNER is already initialized.")

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use alloc::{sync::Arc, vec, vec::Vec};
-use conquer_once::spin::Lazy;
+use conquer_once::spin::{Lazy, OnceCell};
 use multitask::task::Task;
 use spinning_top::Spinlock;
 
@@ -12,6 +12,7 @@ use crate::{
 
 static SPAWN_STATUS: Lazy<Spinlock<Vec<bool>>> =
     Lazy::new(|| Spinlock::new(vec![false; super::max_num().into()]));
+static SPAWNER: OnceCell<Spawner> = OnceCell::uninit();
 
 use super::Port;
 

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -22,6 +22,11 @@ pub fn init(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Rec
         .expect("SPAWNER is already initialized.")
 }
 
+pub fn spawn_all_connected_ports() {
+    let s = SPAWNER.try_get().expect("SPAWNER is not initialized.");
+    s.scan_all_ports_and_spawn();
+}
+
 pub struct Spawner {
     sender: Arc<Futurelock<command::Sender>>,
     receiver: Arc<Spinlock<Receiver>>,

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -16,6 +16,12 @@ static SPAWNER: OnceCell<Spawner> = OnceCell::uninit();
 
 use super::Port;
 
+fn init(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Receiver>>) {
+    SPAWNER
+        .try_init_once(|| Spawner::new(sender, receiver))
+        .expect("SPAWNER is already initialized.")
+}
+
 pub struct Spawner {
     sender: Arc<Futurelock<command::Sender>>,
     receiver: Arc<Spinlock<Receiver>>,

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -1,20 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use super::Port;
+use crate::{
+    device::pci::xhci::exchanger::{command, receiver::Receiver},
+    multitask, Futurelock,
+};
 use alloc::{sync::Arc, vec, vec::Vec};
 use conquer_once::spin::{Lazy, OnceCell};
 use multitask::task::Task;
 use spinning_top::Spinlock;
 
-use crate::{
-    device::pci::xhci::exchanger::{command, receiver::Receiver},
-    multitask, Futurelock,
-};
-
 static SPAWN_STATUS: Lazy<Spinlock<Vec<bool>>> =
     Lazy::new(|| Spinlock::new(vec![false; super::max_num().into()]));
 static SPAWNER: OnceCell<Spawner> = OnceCell::uninit();
-
-use super::Port;
 
 pub fn init(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Receiver>>) {
     SPAWNER


### PR DESCRIPTION
Not to create an instance of `Spawner` to spawn tasks.

bors r+