### PR TITLE
chore: handle the Port Status Change TRB

### DIFF
--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -30,7 +30,7 @@ pub async fn task() {
 
     let (event_ring, runner, command_completion_receiver) = init();
 
-    port::spawn_tasks(runner.clone(), command_completion_receiver.clone());
+    port::spawn_all_connected_port_tasks(runner.clone(), command_completion_receiver.clone());
 
     multitask::add(Task::new_poll(event::task(
         event_ring,

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -102,7 +102,10 @@ async fn init_port_and_slot(
     endpoint::Collection::new(slot, runner).await
 }
 
-pub fn spawn_tasks(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Receiver>>) {
+pub fn spawn_all_connected_port_tasks(
+    sender: Arc<Futurelock<command::Sender>>,
+    receiver: Arc<Spinlock<Receiver>>,
+) {
     spawner::init(sender, receiver);
     spawner::spawn_all_connected_ports();
 }

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -57,6 +57,10 @@ impl ResetPort {
     }
 }
 
+pub fn try_spawn(port_idx: u8) -> Result<(), spawner::PortNotConnected> {
+    spawner::try_spawn(port_idx)
+}
+
 async fn task(
     port: Port,
     runner: Arc<Futurelock<command::Sender>>,

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -25,6 +25,11 @@ pub fn spawn_all_connected_ports() {
     s.spawn_all_connected_ports();
 }
 
+pub fn try_spawn(port_idx: u8) -> Result<(), PortNotConnected> {
+    let s = SPAWNER.try_get().expect("SPAWNER is not initialized.");
+    s.try_spawn(port_idx)
+}
+
 struct Spawner {
     sender: Arc<Futurelock<command::Sender>>,
     receiver: Arc<Spinlock<Receiver>>,

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -21,13 +21,15 @@ pub fn init(sender: Arc<Futurelock<command::Sender>>, receiver: Arc<Spinlock<Rec
 }
 
 pub fn spawn_all_connected_ports() {
-    let s = SPAWNER.try_get().expect("SPAWNER is not initialized.");
-    s.spawn_all_connected_ports();
+    spawner().spawn_all_connected_ports();
 }
 
 pub fn try_spawn(port_idx: u8) -> Result<(), PortNotConnected> {
-    let s = SPAWNER.try_get().expect("SPAWNER is not initialized.");
-    s.try_spawn(port_idx)
+    spawner().try_spawn(port_idx)
+}
+
+fn spawner() -> &'static Spawner {
+    SPAWNER.try_get().expect("SPAWNER is not initialized.")
 }
 
 struct Spawner {

--- a/kernel/src/device/pci/xhci/port/spawner.rs
+++ b/kernel/src/device/pci/xhci/port/spawner.rs
@@ -85,4 +85,4 @@ fn mark_as_spawned(p: &Port) {
 }
 
 #[derive(Debug)]
-struct PortNotConnected;
+pub struct PortNotConnected;

--- a/kernel/src/device/pci/xhci/structures/ring/event/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/event/mod.rs
@@ -20,6 +20,7 @@ use x86_64::{
     structures::paging::{PageSize, Size4KiB},
     PhysAddr,
 };
+use xhci::port;
 
 mod segment_table;
 pub mod trb;
@@ -31,6 +32,8 @@ pub async fn task(mut ring: Ring, command_completion_receiver: Arc<Spinlock<Rece
         if let Trb::Completion(trb) = trb {
             debug!("Command completion TRB arrived.");
             command_completion_receiver.lock().receive(trb);
+        } else if let Trb::PortStatusChange(t) = trb {
+            let _ = port::try_spawn(t.port());
         }
     }
 }

--- a/kernel/src/device/pci/xhci/structures/ring/event/trb/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/event/trb/mod.rs
@@ -32,7 +32,7 @@ add_trb!(PortStatusChange);
 impl PortStatusChange {
     const ID: u8 = 34;
 
-    fn port(&self) -> u8 {
+    pub fn port(&self) -> u8 {
         self.0[0].get_bits(24..=31).try_into().unwrap()
     }
 }

--- a/kernel/src/device/pci/xhci/structures/ring/event/trb/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/event/trb/mod.rs
@@ -31,6 +31,10 @@ impl TryFrom<[u32; 4]> for Trb {
 add_trb!(PortStatusChange);
 impl PortStatusChange {
     const ID: u8 = 34;
+
+    fn port(&self) -> u8 {
+        self.0[0].get_bits(24..=31).try_into().unwrap()
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
- chore: add `PortStatusChange::port`
- refactor: rename to `spawn_all_connected_port_tasks`
- chore: define `try_spawn` function
- refactor: define `spawner` function
- fix: forgot to make `PortNotConnected` public
- chore: make `PortStatusChange::port` public
- chore: spawn a new task after receiving the Port Status Change TRB
