### PR TITLE
refactor: split `syscall.rs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,4 @@
-/target
-bootx64/target
-kernel/target
-debug/target
-common/target
-proc_macros/target
+target/
 **/*.rs.bk
 **/Cargo.lock
 tags

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -47,3 +47,4 @@ num-traits = { version = "0.2", default-features = false}
 num-derive = "0.3.3"
 acpi = { git = "https://github.com/rust-osdev/acpi.git" }
 derive_builder = "0.9.0"
+syscalls = { path = "../syscalls" }

--- a/kernel/src/device/pci/config/mod.rs
+++ b/kernel/src/device/pci/config/mod.rs
@@ -5,7 +5,6 @@ mod common;
 pub mod type_spec;
 
 use self::common::Common;
-use crate::syscall;
 use bar::Bar;
 use core::{convert::TryFrom, ops::Add};
 use type_spec::TypeSpec;
@@ -104,8 +103,8 @@ impl ConfigAddress {
 
     /// SAFETY: `self` must contain the valid config address.
     unsafe fn read(&self) -> u32 {
-        syscall::outl(Self::PORT_CONFIG_ADDR, self.as_u32());
-        syscall::inl(Self::PORT_CONFIG_DATA)
+        syscalls::outl(Self::PORT_CONFIG_ADDR, self.as_u32());
+        syscalls::inl(Self::PORT_CONFIG_DATA)
     }
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -115,7 +115,7 @@ fn initialize_in_user_mode(boot_info: &mut kernelboot::Info) {
 
 fn wait_until_timer_interrupt_happens() -> ! {
     loop {
-        syscall::enable_interrupt_and_halt()
+        syscalls::enable_interrupt_and_halt()
     }
 }
 

--- a/kernel/src/mem/accessor.rs
+++ b/kernel/src/mem/accessor.rs
@@ -4,8 +4,6 @@ use core::{marker::PhantomData, mem, ptr};
 use os_units::Bytes;
 use x86_64::{PhysAddr, VirtAddr};
 
-use crate::syscall;
-
 pub struct Accessor<T: ?Sized> {
     virt: VirtAddr,
     bytes: Bytes, // The size of `T` is not always computable. Thus save the bytes of objects.
@@ -145,8 +143,8 @@ impl Mappers {
 
     fn user() -> Self {
         Self {
-            mapper: syscall::map_pages,
-            unmapper: syscall::unmap_pages,
+            mapper: syscalls::map_pages,
+            unmapper: syscalls::unmap_pages,
         }
     }
 

--- a/kernel/src/mem/allocator/page_box.rs
+++ b/kernel/src/mem/allocator/page_box.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::syscall;
-
 use super::super::paging::pml4::PML4;
 use core::{
     convert::TryFrom,
@@ -145,7 +143,7 @@ impl<T: ?Sized> PageBox<T> {
     }
 
     fn new_zeroed_from_bytes(bytes: Bytes) -> Self {
-        let virt = syscall::allocate_pages(bytes.as_num_of_pages());
+        let virt = syscalls::allocate_pages(bytes.as_num_of_pages());
 
         let mut page_box = Self {
             virt,
@@ -165,6 +163,6 @@ impl<T: ?Sized> PageBox<T> {
 impl<T: ?Sized> Drop for PageBox<T> {
     fn drop(&mut self) {
         let num_of_pages = self.bytes.as_num_of_pages::<Size4KiB>();
-        syscall::deallocate_pages(self.virt, num_of_pages);
+        syscalls::deallocate_pages(self.virt, num_of_pages);
     }
 }

--- a/kernel/src/multitask/executor.rs
+++ b/kernel/src/multitask/executor.rs
@@ -8,8 +8,6 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use crate::syscall;
-
 use super::task;
 use alloc::collections::BTreeMap;
 use core::task::{Context, Poll, Waker};
@@ -34,11 +32,11 @@ impl Executor {
     }
 
     fn sleep_if_idle() {
-        syscall::disable_interrupt();
+        syscalls::disable_interrupt();
         if task::COLLECTION.lock().woken_task_exists() {
-            syscall::enable_interrupt();
+            syscalls::enable_interrupt();
         } else {
-            syscall::enable_interrupt_and_halt();
+            syscalls::enable_interrupt_and_halt();
         }
     }
 

--- a/kernel/src/panic.rs
+++ b/kernel/src/panic.rs
@@ -1,17 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::syscall;
-
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
-    syscall::disable_interrupt();
+    syscalls::disable_interrupt();
     print_banner();
     if let Some(location) = info.location() {
         print_panic_location(location, info);
     }
 
     loop {
-        syscall::halt();
+        syscalls::halt();
     }
 }
 

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+num-derive = "0.3.3"
+num-traits = { version = "0.2.14", default-features = false }
+os_units = "0.2.5"
+x86_64 = "0.12.3"

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "syscalls"
+version = "0.1.0"
+authors = ["toku-sa-n <tokusan441@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1,7 +1,106 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#![no_std]
+#![feature(asm)]
+
+use core::convert::TryInto;
+
+use num_derive::FromPrimitive;
+use os_units::{Bytes, NumOfPages};
+use x86_64::{structures::paging::Size4KiB, PhysAddr, VirtAddr};
+
+/// SAFETY: This function is unsafe because reading a value from I/O port may have side effects which violate memory safety.
+pub unsafe fn inl(port: u16) -> u32 {
+    general_syscall(Ty::Inl, port.into(), 0).try_into().unwrap()
+}
+
+/// SAFETY: This function is unsafe because writing a value via I/O port may have side effects
+/// which violate memory safety.
+pub unsafe fn outl(port: u16, value: u32) {
+    general_syscall(Ty::Outl, port.into(), value.into());
+}
+
+pub fn halt() {
+    // SAFETY: This operation is safe as it does not touch any unsafe things.
+    unsafe { general_syscall(Ty::Halt, 0, 0) };
+}
+
+pub fn disable_interrupt() {
+    // SAFETY: This operation is safe as it does not touch any unsafe things.
+    unsafe { general_syscall(Ty::DisableInterrupt, 0, 0) };
+}
+
+pub fn enable_interrupt() {
+    // SAFETY: This operation is safe as it does not touch any unsafe things.
+    unsafe { general_syscall(Ty::EnableInterrupt, 0, 0) };
+}
+
+pub fn enable_interrupt_and_halt() {
+    // SAFETY: This operation is safe as it does not touch any unsafe things.
+    unsafe { general_syscall(Ty::EnableInterruptAndHalt, 0, 0) };
+}
+
+pub fn allocate_pages(pages: NumOfPages<Size4KiB>) -> VirtAddr {
+    // SAFETY: This operation is safe as the arguments are propertly passed.
+    VirtAddr::new(unsafe {
+        general_syscall(Ty::AllocatePages, pages.as_usize().try_into().unwrap(), 0)
+    })
+}
+
+pub fn deallocate_pages(virt: VirtAddr, pages: NumOfPages<Size4KiB>) {
+    // SAFETY: This operation is safe as the all arguments are propertly passed.
+    unsafe {
+        general_syscall(
+            Ty::DeallocatePages,
+            virt.as_u64(),
+            pages.as_usize().try_into().unwrap(),
+        )
+    };
+}
+
+pub fn map_pages(start: PhysAddr, bytes: Bytes) -> VirtAddr {
+    // SAFETY: This operation is safe as the all arguments are propertly passed.
+    VirtAddr::new(unsafe {
+        general_syscall(
+            Ty::MapPages,
+            start.as_u64(),
+            bytes.as_usize().try_into().unwrap(),
+        )
+    })
+}
+
+pub fn unmap_pages(start: VirtAddr, bytes: Bytes) {
+    unsafe {
+        general_syscall(
+            Ty::UnmapPages,
+            start.as_u64(),
+            bytes.as_usize().try_into().unwrap(),
+        );
     }
+}
+
+/// SAFETY: This function is unsafe if arguments are invalid.
+unsafe fn general_syscall(ty: Ty, a1: u64, a2: u64) -> u64 {
+    let ty = ty as u64;
+    let r: u64;
+    asm!("syscall",
+        inout("rax") ty => r, inout("rdi") a1 => _, inout("rsi") a2 => _, out("rdx") _,
+        out("rcx") _, out("r8") _, out("r9") _, out("r10") _, out("r11") _,);
+    r
+}
+
+#[derive(FromPrimitive)]
+pub enum Ty {
+    Inb,
+    Outb,
+    Inl,
+    Outl,
+    Halt,
+    DisableInterrupt,
+    EnableInterrupt,
+    EnableInterruptAndHalt,
+    AllocatePages,
+    DeallocatePages,
+    MapPages,
+    UnmapPages,
 }


### PR DESCRIPTION
- chore: add `syscalls` crate
- chore: ignore all `target` directory from tracking
- refactor: split `syscalls.rs`

bors r+
