### PR TITLE
chore: warn if a connected device is unrecognized

### DIFF
--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -78,7 +78,7 @@ async fn task(
             let kbd = class_driver::keyboard::Keyboard::new(eps);
             multitask::add(Task::new_poll(class_driver::keyboard::task(kbd)));
         }
-        _ => {}
+        t => warn!("Unknown device: {:?}", t),
     }
 }
 


### PR DESCRIPTION
bors r+
