### PR TITLE
fix: no interruptions from timer

### DIFF
--- a/kernel/src/process/stack_frame.rs
+++ b/kernel/src/process/stack_frame.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use rflags::RFlags;
 use x86_64::{registers::rflags, structures::idt::InterruptStackFrameValue, VirtAddr};
 
 use crate::gdt::GDT;
@@ -11,12 +12,13 @@ pub struct StackFrame {
 }
 impl StackFrame {
     pub fn new(instruction_pointer: VirtAddr, stack_pointer: VirtAddr) -> Self {
+        let cpu_flags = (rflags::read() | RFlags::INTERRUPT_FLAG).bits();
         Self {
             regs: GeneralRegisters::default(),
             interrupt: InterruptStackFrameValue {
                 instruction_pointer,
                 code_segment: GDT.user_code.0.into(),
-                cpu_flags: rflags::read().bits(),
+                cpu_flags,
                 stack_pointer,
                 stack_segment: GDT.user_data.0.into(),
             },


### PR DESCRIPTION
The RFLAGS was created by reading the working one. Processes were created while the interruption was disabled. This is why the timer was not working correctly.

Fixes: #547 

bors r+
