### PR TITLE
fix: scratchpad was ill-aligned

### DIFF
--- a/kernel/src/device/pci/xhci/structures/scratchpad.rs
+++ b/kernel/src/device/pci/xhci/structures/scratchpad.rs
@@ -48,12 +48,15 @@ impl Scratchpad {
     }
 
     fn register_with_dcbaa(&self) {
-        dcbaa::register(0, self.arr.phys_addr());
+        let page_size: u64 = Self::page_size().as_usize().try_into().unwrap();
+        dcbaa::register(0, self.arr.phys_addr().align_up(page_size));
     }
 
     fn allocate_buffers(&mut self) {
         for _ in 0..Self::num_of_buffers() {
-            let b = PageBox::new_slice(0, Self::page_size().as_usize());
+            // Allocate the double size of memory, then register the aligned address with the
+            // array.
+            let b = PageBox::new_slice(0, Self::page_size().as_usize() * 2);
             self.bufs.push(b);
         }
     }


### PR DESCRIPTION
Fixes: #556 

bors r+
