### PR TITLE
fix: wrong endpoint type was generated

### DIFF
--- a/kernel/src/device/pci/xhci/structures/descriptor.rs
+++ b/kernel/src/device/pci/xhci/structures/descriptor.rs
@@ -98,9 +98,14 @@ impl Endpoint {
         EndpointType::from_u8(if self.attributes == 0 {
             4
         } else {
-            self.attributes + if self.endpoint_address == 0 { 0 } else { 4 }
+            self.attributes.get_bits(0..=1)
+                + if self.endpoint_address.get_bit(7) {
+                    4
+                } else {
+                    0
+                }
         })
-        .unwrap()
+        .expect("EndpointType must be convertible from `attributes` and `endpoint_address`.")
     }
 
     pub fn doorbell_value(self) -> u32 {


### PR DESCRIPTION
- fix: wrong endpoint type was specified
- fix: the wrong formula was used to generate `EndpointType`

bors r+
