### PR TITLE
chore(deps): use `acpi` crate on crates.io

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -45,6 +45,6 @@ bit_field = "0.10.1"
 futures-intrusive = { version = "0.4.0", default-features = false, features = ["alloc"] }
 num-traits = { version = "0.2.14", default-features = false }
 num-derive = "0.3.3"
-acpi = { git = "https://github.com/rust-osdev/acpi.git" }
+acpi = "2.2.0"
 derive_builder = "0.9.0"
 syscalls = { path = "../syscalls" }


### PR DESCRIPTION
Fixes: #586 

bors r+
