### PR TITLE
refactor: process module

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -113,11 +113,11 @@ fn initialize_in_user_mode(boot_info: &mut kernelboot::Info) {
 
     process::init();
 
-    process::add(run_tasks, Privilege::User);
+    process::manager::add(run_tasks, Privilege::User);
 
     if cfg!(feature = "qemu_test") {
-        process::add(tests::main, Privilege::User);
-        process::add(tests::process::kernel_privilege_test, Privilege::Kernel);
+        process::manager::add(tests::main, Privilege::User);
+        process::manager::add(tests::process::kernel_privilege_test, Privilege::Kernel);
     }
 }
 

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -31,10 +31,6 @@ pub fn getpid() -> i32 {
     collections::process::handle_running(|p| p.id.as_i32())
 }
 
-pub(super) enum Message {
-    Add(fn() -> !, Privilege),
-}
-
 fn push_process_to_queue(p: Process) {
     add_pid(p.id());
     add_process(p);
@@ -46,4 +42,8 @@ fn add_pid(id: super::Id) {
 
 fn add_process(p: Process) {
     collections::process::add(p);
+}
+
+enum Message {
+    Add(fn() -> !, Privilege),
 }

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -13,18 +13,22 @@ pub fn main() -> ! {
     loop {
         while let Some(Message::Add(f, p)) = MESSAGE.lock().pop_front() {
             match p {
-                Privilege::Kernel => add(Process::kernel(f)),
-                Privilege::User => add(Process::user(f)),
+                Privilege::Kernel => push_process_to_queue(Process::kernel(f)),
+                Privilege::User => push_process_to_queue(Process::user(f)),
             }
         }
     }
 }
 
 pub fn init() {
-    add(Process::user(main));
+    push_process_to_queue(Process::user(main));
 }
 
-fn add(p: Process) {
+pub fn add(f: fn() -> !, p: Privilege) {
+    MESSAGE.lock().push_back(Message::Add(f, p));
+}
+
+fn push_process_to_queue(p: Process) {
     add_pid(p.id());
     add_process(p);
 }
@@ -37,7 +41,7 @@ fn add_process(p: Process) {
     collections::process::add(p);
 }
 
-pub fn getpid() -> i32 {
+pub(crate) fn getpid() -> i32 {
     collections::process::handle_running(|p| p.id.as_i32())
 }
 

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -37,7 +37,7 @@ fn add_process(p: Process) {
     collections::process::add(p);
 }
 
-pub(crate) fn getpid() -> i32 {
+pub fn getpid() -> i32 {
     collections::process::handle_running(|p| p.id.as_i32())
 }
 

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -6,8 +6,7 @@ use conquer_once::spin::Lazy;
 use spinning_top::Spinlock;
 pub use switch::switch;
 
-pub(super) static MESSAGE: Lazy<Spinlock<VecDeque<Message>>> =
-    Lazy::new(|| Spinlock::new(VecDeque::new()));
+static MESSAGE: Lazy<Spinlock<VecDeque<Message>>> = Lazy::new(|| Spinlock::new(VecDeque::new()));
 
 pub fn main() -> ! {
     loop {

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -28,6 +28,14 @@ pub fn add(f: fn() -> !, p: Privilege) {
     MESSAGE.lock().push_back(Message::Add(f, p));
 }
 
+pub fn getpid() -> i32 {
+    collections::process::handle_running(|p| p.id.as_i32())
+}
+
+pub(super) enum Message {
+    Add(fn() -> !, Privilege),
+}
+
 fn push_process_to_queue(p: Process) {
     add_pid(p.id());
     add_process(p);
@@ -39,12 +47,4 @@ fn add_pid(id: super::Id) {
 
 fn add_process(p: Process) {
     collections::process::add(p);
-}
-
-pub fn getpid() -> i32 {
-    collections::process::handle_running(|p| p.id.as_i32())
-}
-
-pub(super) enum Message {
-    Add(fn() -> !, Privilege),
 }

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -41,7 +41,7 @@ fn add_process(p: Process) {
     collections::process::add(p);
 }
 
-pub(crate) fn getpid() -> i32 {
+pub fn getpid() -> i32 {
     collections::process::handle_running(|p| p.id.as_i32())
 }
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -27,10 +27,6 @@ pub fn add(f: fn() -> !, p: Privilege) {
     manager::MESSAGE.lock().push_back(Message::Add(f, p));
 }
 
-pub fn getpid() -> i32 {
-    manager::getpid()
-}
-
 fn register_initial_interrupt_stack_table_addr() {
     TSS.lock().interrupt_stack_table[0] = INTERRUPT_STACK;
 }

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use common::constant::INTERRUPT_STACK;
 use core::sync::atomic::{AtomicI32, Ordering};
-use manager::Message;
 use stack_frame::StackFrame;
 use x86_64::{
     structures::paging::{PageTable, PageTableFlags},
@@ -21,10 +20,6 @@ use x86_64::{
 pub fn init() {
     register_initial_interrupt_stack_table_addr();
     manager::init();
-}
-
-pub fn add(f: fn() -> !, p: Privilege) {
-    manager::MESSAGE.lock().push_back(Message::Add(f, p));
 }
 
 fn register_initial_interrupt_stack_table_addr() {

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -79,6 +79,12 @@ impl Process {
     }
 }
 
+#[derive(Debug)]
+pub enum Privilege {
+    Kernel,
+    User,
+}
+
 #[derive(Copy, Clone, PartialOrd, PartialEq, Ord, Eq, Debug)]
 struct Id(i32);
 impl Id {
@@ -118,10 +124,4 @@ impl Pml4Creator {
     fn map_kernel_area(&mut self) {
         self.pml4[510] = PML4.lock().level_4_table()[510].clone();
     }
-}
-
-#[derive(Debug)]
-pub enum Privilege {
-    Kernel,
-    User,
 }

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -168,5 +168,5 @@ fn sys_unmap_pages(start: VirtAddr, bytes: Bytes) -> u64 {
 }
 
 fn sys_getpid() -> i32 {
-    crate::process::getpid()
+    crate::process::manager::getpid()
 }


### PR DESCRIPTION
- refactor: remove `getpid` from `process` module
- refactor: remove `process::add` function
- refactor: remove an unnecessary `(crate)`
- refactor: public functions should first
- refactor: public things should come first
- refactor: remove an unnecessary `pub`
- refactor: remove an unnecessary `pub`

bors r+
