### PR TITLE
build: remove lines about the debug build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,10 +43,6 @@ jobs:
     - name: Copy OVMF_*
       run: cp /usr/share/OVMF/OVMF_* .
 
-    - name: Test on debug mode
+    - name: Test
       timeout-minutes: 5
       run: make test
-
-    - name: Test on release mode
-      timeout-minutes: 5
-      run: make release_test

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ FAT_IMG			:= $(BUILD_DIR)/fat.img
 INITRD			:= $(BUILD_DIR)/initrd.img
 
 LD				:= ld
-RUSTCC			:= cargo
+RUSTC			:= cargo
 RM				:= rm -rf
 VIEWER			:= qemu-system-x86_64
 
@@ -90,14 +90,14 @@ $(LIB_FILE): $(RUST_SRC) $(COMMON_SRC) $(COMMON_SRC_DIR)/$(CARGO_TOML) $(KERNEL_
 	# FIXME: Currently `cargo` tries to read `$(pwd)/.cargo/config.toml`, not
 	# `$(dirname argument_of_--manifest-path)/.cargo/config.toml`.
 	# See: https://github.com/rust-lang/cargo/issues/2930
-	cd $(KERNEL_DIR) && $(RUSTCC) build --out-dir ../$(BUILD_DIR) -Z unstable-options $(TEST_FLAG) $(RUSTCFLAGS)
+	cd $(KERNEL_DIR) && $(RUSTC) build --out-dir ../$(BUILD_DIR) -Z unstable-options $(TEST_FLAG) $(RUSTCFLAGS)
 
 %.fd:
 	@echo "$@ not found"
 	exit 1
 
 $(EFI_FILE):$(EFI_SRC) $(COMMON_SRC) $(COMMON_SRC_DIR)/$(CARGO_TOML) $(EFI_DIR)/$(CARGO_TOML)|$(BUILD_DIR)
-	cd $(EFI_DIR) && $(RUSTCC) build --out-dir=../$(BUILD_DIR) -Z unstable-options $(RUSTCFLAGS)
+	cd $(EFI_DIR) && $(RUSTC) build --out-dir=../$(BUILD_DIR) -Z unstable-options $(RUSTCFLAGS)
 
 $(INITRD):|$(BUILD_DIR)
 	tar cf $@ $(BUILD_DIR)
@@ -110,5 +110,5 @@ clippy:
 
 clean:
 	$(RM) build
-	$(RUSTCC) clean --manifest-path=$(KERNEL_DIR)/Cargo.toml
-	$(RUSTCC) clean --manifest-path=$(EFI_DIR)/Cargo.toml
+	$(RUSTC) clean --manifest-path=$(KERNEL_DIR)/Cargo.toml
+	$(RUSTC) clean --manifest-path=$(EFI_DIR)/Cargo.toml

--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,11 @@ OVMF_VARS		:= OVMF_VARS.fd
 
 # If you change values of `iobase` and `iosize`, don't forget to change the corresponding values in `kernel/src/lib.rs`!
 VIEWERFLAGS		:= -drive if=pflash,format=raw,file=$(OVMF_CODE),readonly=on -drive if=pflash,format=raw,file=$(OVMF_VARS),readonly=on -drive format=raw,file=$(IMG_FILE) -no-reboot -m 4G -d int -device isa-debug-exit,iobase=0xf4,iosize=0x04 -device qemu-xhci,id=xhci -device usb-kbd --trace events=trace.event -drive id=disk,file=$(FAT_IMG),if=none,format=raw -device ahci,id=ahci -device ide-drive,drive=disk,bus=ahci.0 -device usb-mouse
-
-# This is a workaround for `compiler_builtins` crate which is supported only for optimized build.
-RELEASE_FLAGS	:= --release
+RUSTCFLAGS		:= --release
 
 LDFLAGS			:= -nostdlib -T $(LD_SRC)
 
-.PHONY:all copy_to_usb run test_general test release_test release clippy clean
+.PHONY:all copy_to_usb run test clippy clean
 
 .SUFFIXES:
 
@@ -63,20 +61,12 @@ endif
 run:$(IMG_FILE) $(OVMF_VARS) $(OVMF_CODE) $(FAT_IMG) $(INITRD)
 	$(VIEWER) $(VIEWERFLAGS) -no-shutdown -monitor stdio
 
-test_general:$(INITRD) $(FAT_IMG) $(OVMF_VARS) $(OVMF_CODE)
-	make $(IMG_FILE) RELEASE_FLAGS=$(RELEASE_FLAGS) TEST_FLAG=--features=qemu_test -B
+test:
+	make clean
+	make $(IMG_FILE) TEST_FLAG=--features=qemu_test
 	$(VIEWER) $(VIEWERFLAGS) -nographic; if [[ $$? -eq 33 ]];\
 		then echo "Booting test succeed! ($(TEST_MODE) mode)"; exit 0;\
 		else echo "Booting test failed ($(TEST_MODE) mode)"; exit 1;fi
-
-test:
-	# For some reasons, without `make clean`, consecutive testing will go into the infinite loop.
-	make clean
-	make test_general TEST_MODE=debug
-
-release_test:
-	make clean
-	make test_general TEST_MODE=release RELEASE_FLAGS=--release
 
 $(IMG_FILE):$(KERNEL_FILE) $(HEAD_FILE) $(EFI_FILE) $(INITRD)
 	dd if=/dev/zero of=$@ bs=1k count=28800
@@ -93,12 +83,6 @@ $(IMG_FILE):$(KERNEL_FILE) $(HEAD_FILE) $(EFI_FILE) $(INITRD)
 $(FAT_IMG):$(IMG_FILE)
 	cp $^ $@
 
-release:
-	make RELEASE_FLAGS=--release -B
-
-release_run:
-	make release && make run
-
 $(KERNEL_FILE):$(LIB_FILE) $(LD_SRC)|$(BUILD_DIR)
 	$(LD) $(LDFLAGS) -o $@ $(LIB_FILE)
 
@@ -106,14 +90,14 @@ $(LIB_FILE): $(RUST_SRC) $(COMMON_SRC) $(COMMON_SRC_DIR)/$(CARGO_TOML) $(KERNEL_
 	# FIXME: Currently `cargo` tries to read `$(pwd)/.cargo/config.toml`, not
 	# `$(dirname argument_of_--manifest-path)/.cargo/config.toml`.
 	# See: https://github.com/rust-lang/cargo/issues/2930
-	cd $(KERNEL_DIR) && $(RUSTCC) build --out-dir ../$(BUILD_DIR) -Z unstable-options $(RELEASE_FLAGS) $(TEST_FLAG)
+	cd $(KERNEL_DIR) && $(RUSTCC) build --out-dir ../$(BUILD_DIR) -Z unstable-options $(TEST_FLAG) $(RUSTCFLAGS)
 
 %.fd:
 	@echo "$@ not found"
 	exit 1
 
 $(EFI_FILE):$(EFI_SRC) $(COMMON_SRC) $(COMMON_SRC_DIR)/$(CARGO_TOML) $(EFI_DIR)/$(CARGO_TOML)|$(BUILD_DIR)
-	cd $(EFI_DIR) && $(RUSTCC) build --out-dir=../$(BUILD_DIR) -Z unstable-options $(RELEASE_FLAGS)
+	cd $(EFI_DIR) && $(RUSTCC) build --out-dir=../$(BUILD_DIR) -Z unstable-options $(RUSTCFLAGS)
 
 $(INITRD):|$(BUILD_DIR)
 	tar cf $@ $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test:
 		then echo "Booting test succeed! ($(TEST_MODE) mode)"; exit 0;\
 		else echo "Booting test failed ($(TEST_MODE) mode)"; exit 1;fi
 
-$(IMG_FILE):$(KERNEL_FILE) $(HEAD_FILE) $(EFI_FILE) $(INITRD)
+$(IMG_FILE):$(KERNEL_FILE) $(HEAD_FILE) $(EFI_FILE) $(INITRD) $(FAT_IMG)
 	dd if=/dev/zero of=$@ bs=1k count=28800
 	mformat -i $@ -h 200 -t 500 -s 144::
 	# Cannot replace these mmd and mcopy with `make copy_to_usb` because `mount` needs `sudo`

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -9,12 +9,6 @@ license = "GPL-3.0-or-later"
 default = []
 qemu_test = []
 
-[profile.dev]
-opt-level = 0
-
-# I don't know why lto = false causes some problems like not printing correct words on the screen.
-lto = true
-
 [profile.release]
 opt-level = 3
 lto = true


### PR DESCRIPTION
Still this OS cannot build in the debug mode because of compiler's bugs.
https://github.com/rust-lang/compiler-builtins/issues/327

bors r+
