### PR TITLE
refactor: apply the builder pattern for constructing TRBs

### DIFF
--- a/kernel/src/device/pci/xhci/exchanger/command.rs
+++ b/kernel/src/device/pci/xhci/exchanger/command.rs
@@ -2,7 +2,10 @@
 
 use super::{
     super::structures::ring::{
-        command::{self, trb::Trb},
+        command::{
+            self,
+            trb::{AddressDevice, ConfigureEndpoint, EnableSlot, Noop, Trb},
+        },
         event::trb::completion::Completion,
     },
     receiver::{ReceiveFuture, Receiver},
@@ -27,23 +30,31 @@ impl Sender {
     }
 
     pub async fn noop(&mut self) {
-        let t = Trb::new_noop();
+        let t = Trb::Noop(Noop::default());
         self.issue_trb(t).await;
         info!("NOOP SUCCEESS");
     }
 
     pub async fn enable_device_slot(&mut self) -> u8 {
-        let t = Trb::new_enable_slot();
+        let t = Trb::EnableSlot(EnableSlot::default());
         self.issue_trb(t).await.slot_id()
     }
 
     pub async fn address_device(&mut self, input_context_addr: PhysAddr, slot_id: u8) {
-        let t = Trb::new_address_device(input_context_addr, slot_id);
+        let t = AddressDevice::default()
+            .set_input_context_ptr(input_context_addr)
+            .set_slot_id(slot_id)
+            .clone();
+        let t = Trb::AddressDevice(t);
         self.issue_trb(t).await;
     }
 
     pub async fn configure_endpoint(&mut self, context_addr: PhysAddr, slot_id: u8) {
-        let t = Trb::new_configure_endpoint(context_addr, slot_id);
+        let t = ConfigureEndpoint::default()
+            .set_context_addr(context_addr)
+            .set_slot_id(slot_id)
+            .clone();
+        let t = Trb::ConfigureEndpoint(t);
         self.issue_trb(t).await;
     }
 

--- a/kernel/src/device/pci/xhci/exchanger/command.rs
+++ b/kernel/src/device/pci/xhci/exchanger/command.rs
@@ -41,19 +41,17 @@ impl Sender {
     }
 
     pub async fn address_device(&mut self, input_context_addr: PhysAddr, slot_id: u8) {
-        let t = AddressDevice::default()
+        let t = *AddressDevice::default()
             .set_input_context_ptr(input_context_addr)
-            .set_slot_id(slot_id)
-            .clone();
+            .set_slot_id(slot_id);
         let t = Trb::AddressDevice(t);
         self.issue_trb(t).await;
     }
 
     pub async fn configure_endpoint(&mut self, context_addr: PhysAddr, slot_id: u8) {
-        let t = ConfigureEndpoint::default()
+        let t = *ConfigureEndpoint::default()
             .set_context_addr(context_addr)
-            .set_slot_id(slot_id)
-            .clone();
+            .set_slot_id(slot_id);
         let t = Trb::ConfigureEndpoint(t);
         self.issue_trb(t).await;
     }

--- a/kernel/src/device/pci/xhci/exchanger/transfer.rs
+++ b/kernel/src/device/pci/xhci/exchanger/transfer.rs
@@ -1,12 +1,20 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use core::convert::TryInto;
+
 use super::receiver::{ReceiveFuture, Receiver};
 use crate::{
     device::pci::xhci::{
         self,
         structures::{
             descriptor,
-            ring::{event::trb::completion::Completion, transfer},
+            ring::{
+                event::trb::completion::Completion,
+                transfer::{
+                    self,
+                    trb::control::{Control, Direction, Request},
+                },
+            },
         },
     },
     mem::allocator::page_box::PageBox,
@@ -14,7 +22,10 @@ use crate::{
 use alloc::{sync::Arc, vec::Vec};
 use futures_util::task::AtomicWaker;
 use spinning_top::Spinlock;
-use transfer::trb::{control::DescTyIdx, Normal, Trb};
+use transfer::trb::{
+    control::{DataStage, DescTyIdx, SetupStage, StatusStage},
+    Normal, Trb,
+};
 use x86_64::PhysAddr;
 
 pub struct Sender {
@@ -39,16 +50,49 @@ impl Sender {
 
     pub async fn get_device_descriptor(&mut self) -> PageBox<descriptor::Device> {
         let b = PageBox::user(descriptor::Device::default());
-        let (setup, data, status) =
-            Trb::new_get_descriptor(&b, DescTyIdx::new(descriptor::Ty::Device, 0));
+        let setup = *SetupStage::default()
+            .set_request_type(0b1000_0000)
+            .set_request(Request::GetDescriptor)
+            .set_value(DescTyIdx::new(descriptor::Ty::Device, 0).bits())
+            .set_length(b.bytes().as_usize().try_into().unwrap())
+            .set_trb_transfer_length(8)
+            .set_trt(3);
+        let setup = Trb::Control(Control::Setup(setup));
+
+        let data = *DataStage::default()
+            .set_data_buf(b.phys_addr())
+            .set_transfer_length(b.bytes().as_usize().try_into().unwrap())
+            .set_dir(Direction::In);
+        let data = Trb::Control(Control::Data(data));
+
+        let status = *StatusStage::default().set_ioc(true);
+        let status = Trb::Control(Control::Status(status));
+
         self.issue_trbs(&[setup, data, status]).await;
         b
     }
 
     pub async fn get_configuration_descriptor(&mut self) -> PageBox<[u8]> {
         let b = PageBox::user_slice(0, 4096);
-        let (setup, data, status) =
-            Trb::new_get_descriptor(&b, DescTyIdx::new(descriptor::Ty::Configuration, 0));
+
+        let setup = *SetupStage::default()
+            .set_request_type(0b1000_0000)
+            .set_request(Request::GetDescriptor)
+            .set_value(DescTyIdx::new(descriptor::Ty::Configuration, 0).bits())
+            .set_length(b.bytes().as_usize().try_into().unwrap())
+            .set_trb_transfer_length(8)
+            .set_trt(3);
+        let setup = Trb::Control(Control::Setup(setup));
+
+        let data = *DataStage::default()
+            .set_data_buf(b.phys_addr())
+            .set_transfer_length(b.bytes().as_usize().try_into().unwrap())
+            .set_dir(Direction::In);
+        let data = Trb::Control(Control::Data(data));
+
+        let status = *StatusStage::default().set_ioc(true);
+        let status = Trb::Control(Control::Status(status));
+
         self.issue_trbs(&[setup, data, status]).await;
         debug!("Got TRBs");
         b

--- a/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use super::CycleBit;
+use super::{CycleBit, Link};
 use crate::{device::pci::xhci, mem::allocator::page_box::PageBox};
 use trb::Trb;
 use x86_64::{
@@ -90,7 +90,8 @@ impl Raw {
 
     fn enq_link(&mut self) {
         // Don't call `enqueue`. It will return an `Err` value as there is no space for link TRB.
-        let mut t = Trb::new_link(self.head_addr());
+        let t = Link::default().set_addr(self.head_addr()).clone();
+        let mut t = Trb::Link(t);
         t.set_c(self.c);
         self.raw[self.enq_p] = t.into();
     }

--- a/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
@@ -90,7 +90,7 @@ impl Raw {
 
     fn enq_link(&mut self) {
         // Don't call `enqueue`. It will return an `Err` value as there is no space for link TRB.
-        let t = Link::default().set_addr(self.head_addr()).clone();
+        let t = *Link::default().set_addr(self.head_addr());
         let mut t = Trb::Link(t);
         t.set_c(self.c);
         self.raw[self.enq_p] = t.into();

--- a/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/trb.rs
@@ -17,26 +17,6 @@ pub enum Trb {
 impl Trb {
     pub const SIZE: Bytes = Bytes::new(16);
 
-    pub fn new_noop() -> Self {
-        Self::Noop(Noop::new())
-    }
-
-    pub fn new_enable_slot() -> Self {
-        Self::EnableSlot(EnableSlot::new())
-    }
-
-    pub fn new_link(a: PhysAddr) -> Self {
-        Self::Link(Link::new(a))
-    }
-
-    pub fn new_address_device(input_context_addr: PhysAddr, slot_id: u8) -> Self {
-        Self::AddressDevice(AddressDevice::new(input_context_addr, slot_id))
-    }
-
-    pub fn new_configure_endpoint(context_addr: PhysAddr, slot_id: u8) -> Self {
-        Self::ConfigureEndpoint(ConfigureEndpoint::new(context_addr, slot_id))
-    }
-
     pub fn set_c(&mut self, c: CycleBit) {
         match self {
             Self::Noop(n) => n.set_cycle_bit(c),
@@ -61,13 +41,6 @@ impl From<Trb> for [u32; 4] {
 
 add_trb!(Noop, 23);
 impl_default_simply_adds_trb_id!(Noop);
-impl Noop {
-    fn new() -> Self {
-        let mut t = Self([0; 4]);
-        t.set_trb_type();
-        t
-    }
-}
 
 add_trb!(EnableSlot, 9);
 impl_default_simply_adds_trb_id!(EnableSlot);
@@ -82,40 +55,27 @@ impl EnableSlot {
 add_trb!(AddressDevice, 11);
 impl_default_simply_adds_trb_id!(AddressDevice);
 impl AddressDevice {
-    pub fn new(addr_to_input_context: PhysAddr, slot_id: u8) -> Self {
-        let mut trb = Self([0; 4]);
+    pub fn set_input_context_ptr(&mut self, p: PhysAddr) -> &mut Self {
+        assert!(p.is_aligned(16_u64));
 
-        assert!(addr_to_input_context.is_aligned(16_u64));
-        trb.set_input_context_ptr_as_u64(addr_to_input_context.as_u64());
-        trb.set_trb_type();
-        trb.set_slot_id(slot_id);
-        trb
-    }
-
-    fn set_input_context_ptr_as_u64(&mut self, p: u64) {
+        let p = p.as_u64();
         let l = p & 0xffff_ffff;
         let u = p >> 32;
         self.0[0] = l.try_into().unwrap();
         self.0[1] = u.try_into().unwrap();
+        self
     }
 
-    fn set_slot_id(&mut self, id: u8) {
+    pub fn set_slot_id(&mut self, id: u8) -> &mut Self {
         self.0[3].set_bits(24..=31, id.into());
+        self
     }
 }
 
 add_trb!(ConfigureEndpoint, 12);
 impl_default_simply_adds_trb_id!(ConfigureEndpoint);
 impl ConfigureEndpoint {
-    pub fn new(context_addr: PhysAddr, slot_id: u8) -> Self {
-        let mut t = Self([0; 4]);
-        t.set_context_addr(context_addr);
-        t.set_slot_id(slot_id);
-        t.set_trb_type();
-        t
-    }
-
-    fn set_context_addr(&mut self, a: PhysAddr) {
+    pub fn set_context_addr(&mut self, a: PhysAddr) -> &mut Self {
         assert!(a.is_aligned(16_u64));
 
         let l = a.as_u64() & 0xffff_ffff;
@@ -123,9 +83,11 @@ impl ConfigureEndpoint {
 
         self.0[0] = l.try_into().unwrap();
         self.0[1] = u.try_into().unwrap();
+        self
     }
 
-    fn set_slot_id(&mut self, id: u8) {
+    pub fn set_slot_id(&mut self, id: u8) -> &mut Self {
         self.0[3].set_bits(24..=31, id.into());
+        self
     }
 }

--- a/kernel/src/device/pci/xhci/structures/ring/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use core::convert::{TryFrom, TryInto};
-use os_units::Bytes;
+use core::convert::TryInto;
 use x86_64::PhysAddr;
 
 pub mod command;
@@ -63,21 +62,16 @@ macro_rules! impl_default_simply_adds_trb_id {
 }
 
 add_trb!(Link, 6);
+impl_default_simply_adds_trb_id!(Link);
 impl Link {
-    const SIZE: Bytes = Bytes::new(16);
+    pub fn set_addr(&mut self, a: PhysAddr) -> &mut Self {
+        assert!(a.is_aligned(16_u64));
 
-    fn new(addr_to_ring: PhysAddr) -> Self {
-        assert!(addr_to_ring.is_aligned(u64::try_from(Self::SIZE.as_usize()).unwrap()));
-        let mut trb = Self([0; 4]);
-        trb.set_trb_type();
-        trb.set_addr(addr_to_ring.as_u64());
-        trb
-    }
-
-    fn set_addr(&mut self, a: u64) {
+        let a = a.as_u64();
         let l = a & 0xffff_ffff;
         let u = a >> 32;
         self.0[0] = l.try_into().unwrap();
         self.0[1] = u.try_into().unwrap();
+        self
     }
 }

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use super::CycleBit;
+use super::{CycleBit, Link};
 use crate::mem::allocator::page_box::PageBox;
 use alloc::vec::Vec;
 use trb::Trb;
@@ -81,7 +81,8 @@ impl Raw {
     }
 
     fn append_link_trb(&mut self) {
-        let mut t = Trb::new_link(self.phys_addr());
+        let t = Link::default().set_addr(self.phys_addr()).clone();
+        let mut t = Trb::Link(t);
         t.set_c(self.c);
         self.ring[self.enq_p] = t.into();
     }

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/mod.rs
@@ -81,7 +81,7 @@ impl Raw {
     }
 
     fn append_link_trb(&mut self) {
-        let t = Link::default().set_addr(self.phys_addr()).clone();
+        let t = *Link::default().set_addr(self.phys_addr());
         let mut t = Trb::Link(t);
         t.set_c(self.c);
         self.ring[self.enq_p] = t.into();

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb/control.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb/control.rs
@@ -4,7 +4,6 @@ use crate::{
     add_trb,
     device::pci::xhci::structures::{descriptor, ring::CycleBit},
     impl_default_simply_adds_trb_id,
-    mem::allocator::page_box::PageBox,
 };
 use bit_field::BitField;
 use core::convert::TryInto;
@@ -17,14 +16,6 @@ pub enum Control {
     Status(StatusStage),
 }
 impl Control {
-    pub fn new_get_descriptor<T: ?Sized>(b: &PageBox<T>, dti: DescTyIdx) -> (Self, Self, Self) {
-        let setup = SetupStage::new_get_descriptor(b, dti);
-        let data = DataStage::new(b, Direction::In);
-        let status = StatusStage::new();
-
-        (Self::Setup(setup), Self::Data(data), Self::Status(status))
-    }
-
     pub fn ioc(&self) -> bool {
         // For the control TRBs, only the Status Stage TRB should handle IOC bit. Refer to the note
         // of xHCI dev manual 6.4.1.2
@@ -55,50 +46,39 @@ impl From<Control> for [u32; 4] {
 
 add_trb!(SetupStage, 2);
 impl SetupStage {
-    fn new_get_descriptor<T: ?Sized>(b: &PageBox<T>, dti: DescTyIdx) -> Self {
-        let mut t = Self::null();
-        t.set_request_type(0b1000_0000);
-        t.set_request(Request::GetDescriptor);
-        t.set_value(dti.bits());
-        t.set_length(b.bytes().as_usize().try_into().unwrap());
-        t.set_trb_transfer_length(8);
-        t.set_trb_type();
-        t.set_trt(3);
-        t
-    }
-
-    fn null() -> Self {
-        let mut t = Self([0; 4]);
-        t.set_idt();
-        t
-    }
-
-    fn set_idt(&mut self) {
-        self.0[3].set_bit(6, true);
-    }
-
-    fn set_request_type(&mut self, t: u8) {
+    pub fn set_request_type(&mut self, t: u8) -> &mut Self {
         self.0[0].set_bits(0..=7, t.into());
+        self
     }
 
-    fn set_request(&mut self, r: Request) {
+    pub fn set_request(&mut self, r: Request) -> &mut Self {
         self.0[0].set_bits(8..=15, r as _);
+        self
     }
 
-    fn set_value(&mut self, v: u16) {
+    pub fn set_value(&mut self, v: u16) -> &mut Self {
         self.0[0].set_bits(16..=31, v.into());
+        self
     }
 
-    fn set_length(&mut self, l: u16) {
+    pub fn set_length(&mut self, l: u16) -> &mut Self {
         self.0[1].set_bits(16..=31, l.into());
+        self
     }
 
-    fn set_trb_transfer_length(&mut self, l: u32) {
+    pub fn set_trb_transfer_length(&mut self, l: u32) -> &mut Self {
         self.0[2].set_bits(0..=16, l);
+        self
     }
 
-    fn set_trt(&mut self, t: u8) {
+    pub fn set_trt(&mut self, t: u8) -> &mut Self {
         self.0[3].set_bits(16..=17, t.into());
+        self
+    }
+
+    fn set_idt(&mut self) -> &mut Self {
+        self.0[3].set_bit(6, true);
+        self
     }
 }
 impl Default for SetupStage {
@@ -118,49 +98,39 @@ impl DescTyIdx {
     pub fn new(ty: descriptor::Ty, i: u8) -> Self {
         Self { ty, i }
     }
-    fn bits(self) -> u16 {
+    pub fn bits(self) -> u16 {
         (self.ty as u16) << 8 | u16::from(self.i)
     }
 }
 
-enum Request {
+pub enum Request {
     GetDescriptor = 6,
 }
 
 add_trb!(DataStage, 3);
 impl_default_simply_adds_trb_id!(DataStage);
 impl DataStage {
-    fn new<T: ?Sized>(b: &PageBox<T>, d: Direction) -> Self {
-        let mut t = Self::null();
-        t.set_data_buf(b.phys_addr());
-        t.set_transfer_length(b.bytes().as_usize().try_into().unwrap());
-        t.set_trb_type();
-        t.set_dir(d);
-        t
-    }
-
-    fn null() -> Self {
-        Self([0; 4])
-    }
-
-    fn set_data_buf(&mut self, b: PhysAddr) {
+    pub fn set_data_buf(&mut self, b: PhysAddr) -> &mut Self {
         let l = b.as_u64() & 0xffff_ffff;
         let u = b.as_u64() >> 32;
 
         self.0[0] = l.try_into().unwrap();
         self.0[1] = u.try_into().unwrap();
+        self
     }
 
-    fn set_transfer_length(&mut self, l: u32) {
+    pub fn set_transfer_length(&mut self, l: u32) -> &mut Self {
         self.0[2].set_bits(0..=16, l);
+        self
     }
 
-    fn set_dir(&mut self, d: Direction) {
+    pub fn set_dir(&mut self, d: Direction) -> &mut Self {
         self.0[3].set_bit(16, d.into());
+        self
     }
 }
 
-enum Direction {
+pub enum Direction {
     _Out = 0,
     In = 1,
 }
@@ -176,19 +146,9 @@ impl From<Direction> for bool {
 add_trb!(StatusStage, 4);
 impl_default_simply_adds_trb_id!(StatusStage);
 impl StatusStage {
-    fn new() -> Self {
-        let mut t = Self::null();
-        t.set_ioc(true);
-        t.set_trb_type();
-        t
-    }
-
-    fn null() -> Self {
-        Self([0; 4])
-    }
-
-    fn set_ioc(&mut self, ioc: bool) {
+    pub fn set_ioc(&mut self, ioc: bool) -> &mut Self {
         self.0[3].set_bit(5, ioc);
+        self
     }
 
     fn ioc(&self) -> bool {

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
@@ -28,10 +28,6 @@ impl Trb {
         )
     }
 
-    pub fn new_normal<T: ?Sized>(b: &PageBox<T>) -> Self {
-        Self::Normal(Normal::new(b))
-    }
-
     pub fn set_c(&mut self, c: CycleBit) {
         match self {
             Self::Control(co) => co.set_cycle_bit(c),
@@ -61,29 +57,23 @@ impl From<Trb> for [u32; 4] {
 add_trb!(Normal, 1);
 impl_default_simply_adds_trb_id!(Normal);
 impl Normal {
-    pub fn new<T: ?Sized>(b: &PageBox<T>) -> Self {
-        let mut t = Self([0; 4]);
-        t.set_buf_ptr(b.phys_addr());
-        t.set_transfer_length(b.bytes());
-        t.set_ioc(true);
-        t.set_trb_type();
-        t
-    }
-
-    fn set_buf_ptr(&mut self, p: PhysAddr) {
+    pub fn set_buf_ptr(&mut self, p: PhysAddr) -> &mut Self {
         let l = p.as_u64() & 0xffff_ffff;
         let u = p.as_u64() >> 32;
 
         self.0[0] = l.try_into().unwrap();
         self.0[1] = u.try_into().unwrap();
+        self
     }
 
-    fn set_transfer_length(&mut self, bytes: Bytes) {
+    pub fn set_transfer_length(&mut self, bytes: Bytes) -> &mut Self {
         self.0[2].set_bits(0..=16, bytes.as_usize().try_into().unwrap());
+        self
     }
 
-    fn set_ioc(&mut self, ioc: bool) {
+    pub fn set_ioc(&mut self, ioc: bool) -> &mut Self {
         self.0[3].set_bit(5, ioc);
+        self
     }
 
     fn ioc(&self) -> bool {

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::super::{CycleBit, Link};
-use crate::{add_trb, impl_default_simply_adds_trb_id, mem::allocator::page_box::PageBox};
+use crate::{add_trb, impl_default_simply_adds_trb_id};
 use bit_field::BitField;
-use control::{Control, DescTyIdx};
+use control::Control;
 use core::convert::TryInto;
 use os_units::Bytes;
 use x86_64::PhysAddr;
@@ -18,15 +18,6 @@ pub enum Trb {
 }
 impl Trb {
     pub const SIZE: Bytes = Bytes::new(16);
-
-    pub fn new_get_descriptor<T: ?Sized>(b: &PageBox<T>, dti: DescTyIdx) -> (Self, Self, Self) {
-        let (setup, data, status) = Control::new_get_descriptor(b, dti);
-        (
-            Self::Control(setup),
-            Self::Control(data),
-            Self::Control(status),
-        )
-    }
 
     pub fn set_c(&mut self, c: CycleBit) {
         match self {

--- a/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/transfer/trb/mod.rs
@@ -28,10 +28,6 @@ impl Trb {
         )
     }
 
-    pub fn new_link(a: PhysAddr) -> Self {
-        Self::Link(Link::new(a))
-    }
-
     pub fn new_normal<T: ?Sized>(b: &PageBox<T>) -> Self {
         Self::Normal(Normal::new(b))
     }


### PR DESCRIPTION
- refactor: apply the builder pattern for constructing the Command TRBs
- refactor: dereference instead of `clone`
- refactor: apply the builder pattern for constructing the Normal TRB
- refactor: apply the builder pattern for constructing the Contorl TRBs
- refactor: define `trbs_for_getting_descriptors`

bors r+
