### PR TITLE
chore: fix the license notation position

### DIFF
--- a/kernel/src/device/pci/xhci/port/resetter.rs
+++ b/kernel/src/device/pci/xhci/port/resetter.rs
@@ -1,6 +1,6 @@
-use crate::device::pci::xhci;
-
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::device::pci::xhci;
 
 pub struct Resetter {
     slot: u8,


### PR DESCRIPTION
bors r+
