### PR TITLE
fix: avoid deadlocking by using `ArrayQueue`

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -113,7 +113,10 @@ fn initialize_in_user_mode(boot_info: &mut kernelboot::Info) {
         process::manager::add(tests::main, Privilege::User);
         process::manager::add(tests::process::kernel_privilege_test, Privilege::Kernel);
         process::manager::add(tests::process::exit_test, Privilege::User);
-        process::manager::add(tests::process::do_nothing, Privilege::User);
+
+        for _ in 0..100 {
+            process::manager::add(tests::process::do_nothing, Privilege::User);
+        }
     }
 }
 

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -2,19 +2,19 @@
 
 use super::{collections, collections::woken_pid, switch, Privilege, Process};
 use crate::tss::TSS;
-use alloc::collections::VecDeque;
 use common::constant::INTERRUPT_STACK;
 use conquer_once::spin::Lazy;
-use spinning_top::Spinlock;
+use crossbeam_queue::ArrayQueue;
 
 pub use super::exit::exit;
 pub use switch::switch;
 
-static MESSAGE: Lazy<Spinlock<VecDeque<Message>>> = Lazy::new(|| Spinlock::new(VecDeque::new()));
+const MAX_MESSAGE: usize = 4096;
+static MESSAGE: Lazy<ArrayQueue<Message>> = Lazy::new(|| ArrayQueue::new(MAX_MESSAGE));
 
 pub fn main() {
     loop {
-        while let Some(m) = MESSAGE.lock().pop_front() {
+        while let Some(m) = MESSAGE.pop() {
             match m {
                 Message::Add(f, p) => match p {
                     Privilege::Kernel => push_process_to_queue(Process::kernel(f)),
@@ -40,7 +40,7 @@ pub fn getpid() -> i32 {
 }
 
 pub(super) fn send_message(m: Message) {
-    MESSAGE.lock().push_back(m);
+    MESSAGE.push(m).expect("`MESSAGE` is full.");
 }
 
 pub(super) fn set_temporary_stack_frame() {
@@ -65,6 +65,7 @@ pub(super) fn loader(f: fn()) -> ! {
     syscalls::exit();
 }
 
+#[derive(Debug)]
 pub(super) enum Message {
     Add(fn(), Privilege),
     Exit(super::Id),

--- a/kernel/src/tests/process.rs
+++ b/kernel/src/tests/process.rs
@@ -5,7 +5,7 @@ use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 pub static SWITCH_TEST_SUCCESS: AtomicBool = AtomicBool::new(false);
 
 pub fn count_switch() {
-    const EXIT_GOAL: usize = 100;
+    const EXIT_GOAL: usize = 1000;
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     COUNTER.fetch_add(1, Ordering::Relaxed);
 


### PR DESCRIPTION
Fixes: #652 