### PR TITLE
chore: create stack and stack frame of each process in the address space of the process manager

### DIFF
--- a/kernel/src/process/collections/process.rs
+++ b/kernel/src/process/collections/process.rs
@@ -27,18 +27,6 @@ where
     f(p)
 }
 
-pub(in crate::process) fn handle_running_mut<T, U>(f: T) -> U
-where
-    T: Fn(&mut Process) -> U,
-{
-    let id = woken_pid::active_pid();
-    let mut l = lock_processes();
-    let p = l
-        .get_mut(&id)
-        .unwrap_or_else(|| panic!("Process of PID {} does not exist.", id.as_i32()));
-    f(p)
-}
-
 pub(in crate::process) fn remove(id: process::Id) {
     lock_processes().remove(&id).expect("No such process.");
 }

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -20,17 +20,9 @@ macro_rules! change_stack {
 
 pub fn exit() -> ! {
     change_stack!();
-    free_stack();
     manager::set_temporary_stack_frame();
     send_exit_message();
     cause_timer_interrupt();
-}
-
-fn free_stack() {
-    collections::process::handle_running_mut(|p| {
-        p.stack = None;
-        p.stack_frame = None;
-    });
 }
 
 fn send_exit_message() {

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -21,10 +21,10 @@ use x86_64::{
 #[derive(Debug)]
 pub struct Process {
     id: Id,
-    stack: PageBox<[u8]>,
     f: fn(),
     tables: page_table::Collection,
     pml4_addr: PhysAddr,
+    stack: PageBox<[u8]>,
     stack_frame: PageBox<StackFrame>,
     privilege: Privilege,
 }
@@ -54,10 +54,10 @@ impl Process {
 
         Process {
             id: Id::new(),
-            stack,
             f,
             tables,
             pml4_addr,
+            stack,
             stack_frame,
             privilege,
         }

--- a/kernel/src/process/page_table.rs
+++ b/kernel/src/process/page_table.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::mem::{allocator::page_box::PageBox, paging::pml4::PML4};
+use alloc::collections::BTreeMap;
+use core::convert::TryFrom;
+use os_units::NumOfPages;
+use x86_64::{
+    structures::paging::{
+        Page, PageSize, PageTable, PageTableFlags, PageTableIndex, PhysFrame, Size4KiB,
+    },
+    PhysAddr, VirtAddr,
+};
+
+#[derive(Debug)]
+pub(super) struct Collection {
+    pml4: PageBox<PageTable>,
+    pdpt: BTreeMap<PageTableIndex, PageBox<PageTable>>,
+    pd: BTreeMap<PageTableIndex, PageBox<PageTable>>,
+    pt: BTreeMap<PageTableIndex, PageBox<PageTable>>,
+}
+impl Collection {
+    pub(super) fn pml4_addr(&self) -> PhysAddr {
+        self.pml4.phys_addr()
+    }
+
+    pub(super) fn map_page_box<T: ?Sized>(&mut self, b: &PageBox<T>) {
+        self.map_pages_page_aligned(b.virt_addr(), b.phys_addr(), b.bytes().as_num_of_pages());
+    }
+
+    fn map_pages_page_aligned(&mut self, v: VirtAddr, p: PhysAddr, n: NumOfPages<Size4KiB>) {
+        assert!(v.is_aligned(Size4KiB::SIZE), "`v` is not page-aligned.");
+        assert!(p.is_aligned(Size4KiB::SIZE), "`p` is not page-aligned.");
+
+        for i in 0..n.as_usize() {
+            let off = Size4KiB::SIZE * u64::try_from(i).unwrap();
+            let v = Page::from_start_address(v + off).expect("Page is not aligned.");
+            let p = PhysFrame::from_start_address(p + off).expect("Frame is not aligned.");
+            self.map(v, p);
+        }
+    }
+
+    fn map(&mut self, v: Page<Size4KiB>, p: PhysFrame) {
+        let Self { pml4, pdpt, pd, pt } = self;
+
+        let pml4_i = v.p4_index();
+        let pdpt_i = v.p3_index();
+        let dir_i = v.p2_index();
+        let table_i = v.p1_index();
+
+        let p3 = pdpt
+            .entry(pml4_i)
+            .or_insert_with(|| Self::create(pml4, pml4_i));
+
+        let p2 = pd.entry(pdpt_i).or_insert_with(|| Self::create(p3, pdpt_i));
+
+        let p1 = pt.entry(dir_i).or_insert_with(|| Self::create(p2, dir_i));
+
+        p1[table_i].set_addr(p.start_address(), Self::flags());
+    }
+
+    fn create(parent: &mut PageTable, i: PageTableIndex) -> PageBox<PageTable> {
+        let t = PageBox::user(PageTable::new());
+        Self::map_transition(parent, &t, i);
+        t
+    }
+
+    fn map_transition(from: &mut PageTable, to: &PageBox<PageTable>, i: PageTableIndex) {
+        from[i].set_addr(to.phys_addr(), Self::flags());
+    }
+
+    fn flags() -> PageTableFlags {
+        PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::USER_ACCESSIBLE
+    }
+}
+impl Default for Collection {
+    fn default() -> Self {
+        Self {
+            pml4: Pml4Creator::default().create(),
+            pdpt: BTreeMap::default(),
+            pd: BTreeMap::default(),
+            pt: BTreeMap::default(),
+        }
+    }
+}
+
+struct Pml4Creator {
+    pml4: PageBox<PageTable>,
+}
+impl Pml4Creator {
+    fn create(mut self) -> PageBox<PageTable> {
+        self.enable_recursive_paging();
+        self.map_kernel_area();
+        self.pml4
+    }
+
+    fn enable_recursive_paging(&mut self) {
+        let a = self.pml4.phys_addr();
+        let f =
+            PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::USER_ACCESSIBLE;
+        self.pml4[511].set_addr(a, f);
+    }
+
+    fn map_kernel_area(&mut self) {
+        self.pml4[510] = PML4.lock().level_4_table()[510].clone();
+    }
+}
+impl Default for Pml4Creator {
+    fn default() -> Self {
+        Self {
+            pml4: PageBox::user(PageTable::new()),
+        }
+    }
+}


### PR DESCRIPTION
- chore: create page tables of each process in the process manager space
- refactor: change the order of members
- refactor: remove an unused function

Fixes: #630

bors r+
