### PR TITLE
chore: implement `Clone` for `PageBox`

### DIFF
--- a/kernel/src/tests/mem.rs
+++ b/kernel/src/tests/mem.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use page_box::PageBox;
+
+pub(super) fn main() {
+    test_page_box_clone();
+}
+
+fn test_page_box_clone() {
+    let b = PageBox::new(3);
+    let b2 = b.clone();
+
+    assert_eq!(*b, *b2);
+
+    let b = PageBox::new_slice(334, 5);
+    let b2 = b.clone();
+
+    assert_eq!(*b, *b2);
+}

--- a/kernel/src/tests/mod.rs
+++ b/kernel/src/tests/mod.rs
@@ -3,11 +3,13 @@
 use core::sync::atomic::Ordering;
 use qemu_exit::QEMUExit;
 
+mod mem;
 pub mod process;
 mod syscall;
 
 pub fn main() {
     self::syscall::main();
+    self::mem::main();
 
     while !process::SWITCH_TEST_SUCCESS.load(Ordering::Relaxed) {}
 

--- a/page_box/src/lib.rs
+++ b/page_box/src/lib.rs
@@ -164,18 +164,10 @@ impl<T: ?Sized> PageBox<T> {
             panic!("Failed to allocate pages.");
         }
 
-        let mut page_box = Self {
+        Self {
             virt,
             bytes,
             _marker: PhantomData,
-        };
-        page_box.write_all_bytes_with_zero();
-        page_box
-    }
-
-    fn write_all_bytes_with_zero(&mut self) {
-        unsafe {
-            core::ptr::write_bytes(self.virt.as_mut_ptr::<u8>(), 0, self.bytes.as_usize());
         }
     }
 }

--- a/page_box/src/lib.rs
+++ b/page_box/src/lib.rs
@@ -81,7 +81,7 @@ where
 
 impl<T> PageBox<[T]>
 where
-    T: Copy + Clone,
+    T: Clone,
 {
     pub fn new_slice(x: T, num_of_elements: usize) -> Self {
         let bytes = Bytes::new(mem::size_of::<T>() * num_of_elements);
@@ -90,16 +90,13 @@ where
         page_box
     }
 
-    fn write_all_elements_with_same_value(&mut self, x: T)
-    where
-        T: Copy + Clone,
-    {
+    fn write_all_elements_with_same_value(&mut self, x: T) {
         for i in 0..self.len() {
             let ptr: usize = usize::try_from(self.virt.as_u64()).unwrap() + mem::size_of::<T>() * i;
 
             // SAFETY: This operation is safe. The memory ptr points is allocated and is aligned
             // because the first elements is page-aligned.
-            unsafe { ptr::write(ptr as *mut T, x) }
+            unsafe { ptr::write(ptr as *mut T, x.clone()) }
         }
     }
 
@@ -109,7 +106,7 @@ where
 }
 impl<T> Deref for PageBox<[T]>
 where
-    T: Copy + Clone,
+    T: Clone,
 {
     type Target = [T];
     fn deref(&self) -> &Self::Target {
@@ -118,7 +115,7 @@ where
 }
 impl<T> DerefMut for PageBox<[T]>
 where
-    T: Copy + Clone,
+    T: Clone,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { slice::from_raw_parts_mut(self.virt.as_mut_ptr(), self.num_of_elements()) }
@@ -126,7 +123,7 @@ where
 }
 impl<T> fmt::Display for PageBox<[T]>
 where
-    T: Copy + Clone,
+    T: Clone,
     [T]: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -135,7 +132,7 @@ where
 }
 impl<T> fmt::Debug for PageBox<[T]>
 where
-    T: Copy + Clone,
+    T: Clone,
     [T]: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/page_box/src/lib.rs
+++ b/page_box/src/lib.rs
@@ -139,6 +139,20 @@ where
         fmt::Debug::fmt(&**self, f)
     }
 }
+impl<T> Clone for PageBox<[T]>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        let mut b = Self::new_slice(self[0].clone(), self.len());
+
+        for (dst, src) in b.iter_mut().zip(self.iter()) {
+            *dst = src.clone();
+        }
+
+        b
+    }
+}
 
 impl<T: ?Sized> PageBox<T> {
     #[must_use]

--- a/page_box/src/lib.rs
+++ b/page_box/src/lib.rs
@@ -70,6 +70,14 @@ where
         Self::new(T::default())
     }
 }
+impl<T> Clone for PageBox<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Self::new((&**self).clone())
+    }
+}
 
 impl<T> PageBox<[T]>
 where


### PR DESCRIPTION
- refactor: remove an unnecessary method
- chore: implement `Clone` for `PageBox<T>`
- refactor: remove `Copy` trait bound
- chore: implement `Clone` for `PageBox<[T]>`
- test: add a test for cloning page boxes

bors r+
