### PR TITLE
refactor: rewrite with `xhci` crate

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -44,4 +44,4 @@ syscalls = { path = "../syscalls" }
 tsukemen = { path = "../apps/tsukemen" }
 page_box = { path = "../page_box" }
 terminal = { path = "../terminal" }
-xhci = "0.2.0"
+xhci = "0.2.2"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -44,3 +44,4 @@ syscalls = { path = "../syscalls" }
 tsukemen = { path = "../apps/tsukemen" }
 page_box = { path = "../page_box" }
 terminal = { path = "../terminal" }
+xhci = "0.2.0"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -44,4 +44,4 @@ syscalls = { path = "../syscalls" }
 tsukemen = { path = "../apps/tsukemen" }
 page_box = { path = "../page_box" }
 terminal = { path = "../terminal" }
-xhci = "0.2.2"
+xhci = "0.2.3"

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -98,7 +98,7 @@ pub fn spawn_all_connected_port_tasks() {
 fn max_num() -> u8 {
     super::handle_registers(|r| {
         let params1 = r.capability.hcs_params_1.read();
-        params1.max_ports()
+        params1.number_of_ports()
     })
 }
 

--- a/kernel/src/device/pci/xhci/structures/context.rs
+++ b/kernel/src/device/pci/xhci/structures/context.rs
@@ -50,7 +50,7 @@ impl Input {
     fn csz() -> bool {
         xhci::handle_registers(|r| {
             let p1 = r.capability.hc_cp_params_1.read();
-            p1.csz()
+            p1.context_size()
         })
     }
 }

--- a/kernel/src/device/pci/xhci/structures/dcbaa.rs
+++ b/kernel/src/device/pci/xhci/structures/dcbaa.rs
@@ -34,14 +34,18 @@ impl<'a> DeviceContextBaseAddressArray {
     fn num_of_slots() -> usize {
         xhci::handle_registers(|r| {
             let p = &r.capability.hcs_params_1;
-            (p.read().max_slots() + 1).into()
+            (p.read().number_of_device_slots() + 1).into()
         })
     }
 
     fn register_address_to_xhci_register(&self) {
         xhci::handle_registers(|r| {
             let p = &mut r.operational.dcbaap;
-            p.update(|dcbaap| dcbaap.set(self.phys_addr()));
+            p.update(|dcbaap| {
+                dcbaap.set(self.phys_addr().as_u64()).expect(
+                    "The Device Context Base Address Array Base Pointer is not aligned correctly.",
+                )
+            });
         })
     }
 

--- a/kernel/src/device/pci/xhci/structures/registers/capability.rs
+++ b/kernel/src/device/pci/xhci/structures/registers/capability.rs
@@ -1,15 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use crate::mem::accessor::Accessor;
-use bitfield::bitfield;
 use os_units::Bytes;
 use x86_64::PhysAddr;
+use xhci::registers::capability::{
+    CapabilityParameters1, CapabilityRegistersLength, DoorbellOffset, RuntimeRegisterSpaceOffset,
+    StructuralParameters1, StructuralParameters2,
+};
 
 pub struct Capability {
-    pub cap_length: Accessor<Len>,
+    pub cap_length: Accessor<CapabilityRegistersLength>,
     pub hcs_params_1: Accessor<StructuralParameters1>,
     pub hcs_params_2: Accessor<StructuralParameters2>,
-    pub hc_cp_params_1: Accessor<HCCapabilityParameters1>,
+    pub hc_cp_params_1: Accessor<CapabilityParameters1>,
     pub db_off: Accessor<DoorbellOffset>,
     pub rts_off: Accessor<RuntimeRegisterSpaceOffset>,
 }
@@ -33,63 +36,5 @@ impl Capability {
             db_off,
             rts_off,
         }
-    }
-}
-
-#[repr(transparent)]
-pub struct Len(u8);
-impl Len {
-    pub fn get(&self) -> usize {
-        self.0 as _
-    }
-}
-
-bitfield! {
-    #[repr(transparent)]
-    pub struct StructuralParameters1(u32);
-    pub u8, max_slots, _: 7, 0;
-    pub u8, max_ports, _: 31, 24;
-}
-
-bitfield! {
-    #[repr(transparent)]
-    pub struct StructuralParameters2(u32);
-    erst_max, _: 7, 4;
-    max_scratchpad_bufs_hi, _: 25, 20;
-    max_scratchpad_bufs_lo, _: 31, 27;
-}
-impl StructuralParameters2 {
-    pub fn powered_erst_max(&self) -> u16 {
-        2_u16.pow(self.erst_max())
-    }
-
-    pub fn max_scratchpad_bufs(&self) -> u32 {
-        let h = self.max_scratchpad_bufs_hi();
-        let l = self.max_scratchpad_bufs_lo();
-
-        h << 5 | l
-    }
-}
-
-bitfield! {
-    #[repr(transparent)]
-    pub struct HCCapabilityParameters1(u32);
-    pub csz, _: 2;
-    pub xhci_extended_capabilities_pointer,_: 31,16;
-}
-
-#[repr(transparent)]
-pub struct DoorbellOffset(u32);
-impl DoorbellOffset {
-    pub fn get(&self) -> u32 {
-        self.0
-    }
-}
-
-#[repr(transparent)]
-pub struct RuntimeRegisterSpaceOffset(u32);
-impl RuntimeRegisterSpaceOffset {
-    pub fn get(&self) -> u32 {
-        self.0 & !0x1f
     }
 }

--- a/kernel/src/device/pci/xhci/structures/registers/runtime.rs
+++ b/kernel/src/device/pci/xhci/structures/registers/runtime.rs
@@ -4,6 +4,10 @@ use crate::mem::accessor::Accessor;
 use bitfield::bitfield;
 use os_units::Bytes;
 use x86_64::PhysAddr;
+use xhci::registers::runtime::{
+    EventRingDequeuePointerRegister, EventRingSegmentTableBaseAddressRegister,
+    EventRingSegmentTableSizeRegister,
+};
 
 pub struct Runtime {
     pub erst_sz: Accessor<EventRingSegmentTableSizeRegister>,
@@ -40,33 +44,4 @@ bitfield! {
     struct InterruptModerationRegister(u32);
 
     interrupt_moderation_interval, set_interrupt_interval: 15, 0;
-}
-
-#[repr(transparent)]
-#[derive(Debug)]
-pub struct EventRingSegmentTableSizeRegister(u32);
-impl EventRingSegmentTableSizeRegister {
-    pub fn set(&mut self, val: u16) {
-        self.0 = u32::from(val)
-    }
-}
-
-#[repr(transparent)]
-#[derive(Debug)]
-pub struct EventRingSegmentTableBaseAddressRegister(u64);
-impl EventRingSegmentTableBaseAddressRegister {
-    pub fn set(&mut self, addr: PhysAddr) {
-        let addr = addr.as_u64();
-        assert!(addr.trailing_zeros() >= 6);
-        self.0 = addr
-    }
-}
-
-#[repr(transparent)]
-pub struct EventRingDequeuePointerRegister(u64);
-impl EventRingDequeuePointerRegister {
-    pub fn set(&mut self, addr: PhysAddr) {
-        assert!(addr.as_u64().trailing_zeros() >= 4);
-        self.0 = addr.as_u64();
-    }
 }

--- a/kernel/src/device/pci/xhci/structures/registers/runtime.rs
+++ b/kernel/src/device/pci/xhci/structures/registers/runtime.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use crate::mem::accessor::Accessor;
-use bitfield::bitfield;
 use os_units::Bytes;
 use x86_64::PhysAddr;
 use xhci::registers::runtime::{
@@ -29,19 +28,4 @@ impl<'a> Runtime {
             erd_p,
         }
     }
-}
-
-bitfield! {
-    #[repr(transparent)]
-     struct InterruptManagementRegister(u32);
-
-     interrupt_pending,set_interrupt_pending: 0;
-     interrupt_enable, set_interrupt_status: 1;
-}
-
-bitfield! {
-    #[repr(transparent)]
-    struct InterruptModerationRegister(u32);
-
-    interrupt_moderation_interval, set_interrupt_interval: 15, 0;
 }

--- a/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
@@ -131,7 +131,8 @@ impl<'a> Initializer<'a> {
             // Do not split this closure to avoid read-modify-write bug. Reading fields may return
             // 0, this will cause writing 0 to fields.
             c.update(|c| {
-                c.set_command_ring_pointer(a.as_u64());
+                c.set_command_ring_pointer(a.as_u64())
+                    .expect("The Command Ring Pointer is not aligned properly.");
                 c.set_ring_cycle_state(true);
                 info!("CRCR: {:X?}", c);
             });

--- a/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
@@ -131,7 +131,7 @@ impl<'a> Initializer<'a> {
             // Do not split this closure to avoid read-modify-write bug. Reading fields may return
             // 0, this will cause writing 0 to fields.
             c.update(|c| {
-                c.set_ptr(a);
+                c.set_command_ring_pointer(a.as_u64());
                 c.set_ring_cycle_state(true);
                 info!("CRCR: {:X?}", c);
             });

--- a/kernel/src/device/pci/xhci/structures/scratchpad.rs
+++ b/kernel/src/device/pci/xhci/structures/scratchpad.rs
@@ -69,10 +69,10 @@ impl Scratchpad {
     }
 
     fn num_of_buffers() -> u32 {
-        xhci::handle_registers(|r| r.capability.hcs_params_2.read().max_scratchpad_bufs())
+        xhci::handle_registers(|r| r.capability.hcs_params_2.read().max_scratchpad_buffers())
     }
 
     fn page_size() -> Bytes {
-        xhci::handle_registers(|r| r.operational.page_size.read().as_bytes())
+        Bytes::new(xhci::handle_registers(|r| r.operational.page_size.read().get()).into())
     }
 }

--- a/kernel/src/device/pci/xhci/xhc.rs
+++ b/kernel/src/device/pci/xhci/xhc.rs
@@ -24,7 +24,7 @@ pub fn ensure_no_error_occurs() {
             !s.host_system_error(),
             "An error occured on the host system."
         );
-        assert!(!s.hc_error(), "An error occured on the xHC.");
+        assert!(!s.host_controller_error(), "An error occured on the xHC.");
     });
 }
 
@@ -71,14 +71,14 @@ fn reset() {
 fn start_resetting() {
     super::handle_registers(|r| {
         let c = &mut r.operational.usb_cmd;
-        c.update(|c| c.set_hc_reset(true));
+        c.update(|c| c.set_host_controller_reset(true));
     })
 }
 
 fn wait_until_reset_completed() {
     super::handle_registers(|r| {
         let c = &r.operational.usb_cmd;
-        while c.read().hc_reset() {}
+        while c.read().host_controller_reset() {}
     })
 }
 
@@ -100,6 +100,6 @@ fn set_num_of_enabled_slots() {
 fn num_of_device_slots() -> u8 {
     super::handle_registers(|r| {
         let p = &r.capability.hcs_params_1;
-        p.read().max_slots()
+        p.read().number_of_device_slots()
     })
 }


### PR DESCRIPTION
- chore: update the version of `xhci` to 0.2.0
- chore: rewrite with `xhci` crate
- chore: rewrite with `xhci` crate
- refactor: rewrite with `xhci` crate
- refactor: remove unused lines
- fix: method names
- chore: update the version of `xhci` crate
- refactor: rewrite with `xhci` crate
- chore: update the version of the `xhci` crate

bors r+
