### PR TITLE
refactor: create `registers` and `extended_capabilities` modules

### DIFF
--- a/kernel/src/device/pci/xhci/exchanger/transfer.rs
+++ b/kernel/src/device/pci/xhci/exchanger/transfer.rs
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::receiver::{self, ReceiveFuture};
-use crate::device::pci::xhci::{
-    self,
-    structures::{
-        descriptor,
-        ring::{
-            event::trb::completion::Completion,
-            transfer::{
-                self,
-                trb::control::{Control, Direction, Request},
-            },
+use crate::device::pci::xhci::structures::{
+    descriptor, registers,
+    ring::{
+        event::trb::completion::Completion,
+        transfer::{
+            self,
+            trb::control::{Control, Direction, Request},
         },
     },
 };
@@ -148,7 +145,7 @@ impl DoorbellWriter {
     }
 
     pub fn write(&mut self) {
-        xhci::handle_registers(|r| {
+        registers::handle(|r| {
             r.doorbell.update_at(self.slot_id.into(), |d| {
                 d.set_doorbell_target(self.val.try_into().unwrap())
             })

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -5,8 +5,6 @@ mod port;
 mod structures;
 mod xhc;
 
-use core::convert::TryInto;
-
 use super::config::bar;
 use crate::{
     mem::accessor::Mappers,
@@ -14,17 +12,17 @@ use crate::{
 };
 use alloc::sync::Arc;
 use conquer_once::spin::OnceCell;
+use core::convert::TryInto;
 use extended_capabilities::ExtendedCapability;
 use spinning_top::Spinlock;
 use structures::{
-    dcbaa,
+    dcbaa, registers,
     ring::{command, event},
     scratchpad,
 };
 use x86_64::PhysAddr;
-use xhci::{extended_capabilities, registers::Registers};
+use xhci::extended_capabilities;
 
-static REGISTERS: OnceCell<Spinlock<Registers<Mappers>>> = OnceCell::uninit();
 static EXTENDED_CAPABILITIES: OnceCell<Spinlock<Option<extended_capabilities::List<Mappers>>>> =
     OnceCell::uninit();
 
@@ -47,7 +45,7 @@ pub async fn task() {
 fn init_statics() -> Result<(), XhcNotFound> {
     match iter_devices().next() {
         Some(a) => {
-            init_registers(a);
+            registers::init(a);
             init_extended_capabilities(a);
             Ok(())
         }
@@ -55,23 +53,8 @@ fn init_statics() -> Result<(), XhcNotFound> {
     }
 }
 
-fn init_registers(mmio_base: PhysAddr) {
-    REGISTERS
-        .try_init_once(|| {
-            Spinlock::new(
-                // SAFETY: The address is the correct one and the Registers are accessed only through
-                // this static.
-                unsafe {
-                    Registers::new(mmio_base.as_u64().try_into().unwrap(), Mappers::user())
-                        .expect("The MMIO base address of the xHC is not aligned correctly.")
-                },
-            )
-        })
-        .expect("Failed to initialize `REGISTERS`.")
-}
-
 fn init_extended_capabilities(mmio_base: PhysAddr) {
-    let hccparams1 = handle_registers(|r| r.capability.hccparams1.read());
+    let hccparams1 = registers::handle(|r| r.capability.hccparams1.read());
 
     EXTENDED_CAPABILITIES
         .try_init_once(|| {
@@ -92,22 +75,6 @@ fn init_extended_capabilities(mmio_base: PhysAddr) {
 
 #[derive(Debug)]
 struct XhcNotFound;
-
-/// Handle xHCI registers.
-///
-/// To avoid deadlocking, this method takes a closure. Caller is supposed not to call this method
-/// inside the closure, otherwise a deadlock will happen.
-///
-/// Alternative implementation is to define a method which returns `impl Deref<Target =
-/// Registers>`, but this will expand the scope of the mutex guard, increasing the possibility of
-/// deadlocks.
-fn handle_registers<T, U>(f: T) -> U
-where
-    T: Fn(&mut Registers<Mappers>) -> U,
-{
-    let mut r = REGISTERS.try_get().unwrap().lock();
-    f(&mut r)
-}
 
 fn iter_extended_capabilities() -> Option<
     impl Iterator<Item = Result<ExtendedCapability<Mappers>, extended_capabilities::NotSupportedId>>,

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -6,25 +6,15 @@ mod structures;
 mod xhc;
 
 use super::config::bar;
-use crate::{
-    mem::accessor::Mappers,
-    multitask::{self, task::Task},
-};
+use crate::multitask::{self, task::Task};
 use alloc::sync::Arc;
-use conquer_once::spin::OnceCell;
-use core::convert::TryInto;
-use extended_capabilities::ExtendedCapability;
 use spinning_top::Spinlock;
 use structures::{
-    dcbaa, registers,
+    dcbaa, extended_capabilities, registers,
     ring::{command, event},
     scratchpad,
 };
 use x86_64::PhysAddr;
-use xhci::extended_capabilities;
-
-static EXTENDED_CAPABILITIES: OnceCell<Spinlock<Option<extended_capabilities::List<Mappers>>>> =
-    OnceCell::uninit();
 
 pub async fn task() {
     if init_statics().is_err() {
@@ -46,48 +36,15 @@ fn init_statics() -> Result<(), XhcNotFound> {
     match iter_devices().next() {
         Some(a) => {
             registers::init(a);
-            init_extended_capabilities(a);
+            extended_capabilities::init(a);
             Ok(())
         }
         None => Err(XhcNotFound),
     }
 }
 
-fn init_extended_capabilities(mmio_base: PhysAddr) {
-    let hccparams1 = registers::handle(|r| r.capability.hccparams1.read());
-
-    EXTENDED_CAPABILITIES
-        .try_init_once(|| {
-            Spinlock::new(
-                // SAFETY: The address is the correct one and the Extended Capabilities are accessed only through
-                // this static.
-                unsafe {
-                    extended_capabilities::List::new(
-                        mmio_base.as_u64().try_into().unwrap(),
-                        hccparams1,
-                        Mappers::user(),
-                    )
-                },
-            )
-        })
-        .expect("Failed to initialize `EXTENDED_CAPABILITIES`.");
-}
-
 #[derive(Debug)]
 struct XhcNotFound;
-
-fn iter_extended_capabilities() -> Option<
-    impl Iterator<Item = Result<ExtendedCapability<Mappers>, extended_capabilities::NotSupportedId>>,
-> {
-    Some(
-        EXTENDED_CAPABILITIES
-            .try_get()
-            .expect("`EXTENDED_CAPABILITIES` is not initialized.`")
-            .lock()
-            .as_mut()?
-            .into_iter(),
-    )
-}
 
 fn init() -> event::Ring {
     let mut event_ring = event::Ring::new();

--- a/kernel/src/device/pci/xhci/port/endpoint.rs
+++ b/kernel/src/device/pci/xhci/port/endpoint.rs
@@ -2,11 +2,10 @@
 
 use super::Slot;
 use crate::device::pci::xhci::{
-    self,
     exchanger::{self, transfer},
     structures::{
         context::{self, Context},
-        descriptor,
+        descriptor, registers,
         ring::CycleBit,
     },
 };
@@ -146,7 +145,7 @@ impl Default {
     // The actual port speed is listed on the xHCI supported protocol capability.
     // Check the capability and fetch the actual port speed. Then return the max packet size.
     fn get_max_packet_size(&self) -> u16 {
-        let psi = xhci::handle_registers(|r| {
+        let psi = registers::handle(|r| {
             r.port_register_set
                 .read_at((self.port_id - 1).into())
                 .portsc

--- a/kernel/src/device/pci/xhci/port/mod.rs
+++ b/kernel/src/device/pci/xhci/port/mod.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use super::{exchanger, structures::context::Context};
+use super::{
+    exchanger,
+    structures::{context::Context, registers},
+};
 use crate::multitask::{self, task::Task};
 use alloc::collections::VecDeque;
 use conquer_once::spin::Lazy;
@@ -94,7 +97,7 @@ pub fn spawn_all_connected_port_tasks() {
 }
 
 fn max_num() -> u8 {
-    super::handle_registers(|r| r.capability.hcsparams1.read().number_of_ports())
+    registers::handle(|r| r.capability.hcsparams1.read().number_of_ports())
 }
 
 pub struct Port {
@@ -124,7 +127,7 @@ impl Port {
     }
 
     fn read_port_rg(&self) -> PortRegisterSet {
-        super::handle_registers(|r| r.port_register_set.read_at((self.index - 1).into()))
+        registers::handle(|r| r.port_register_set.read_at((self.index - 1).into()))
     }
 }
 

--- a/kernel/src/device/pci/xhci/port/resetter.rs
+++ b/kernel/src/device/pci/xhci/port/resetter.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::device::pci::xhci;
+use crate::device::pci::xhci::registers;
 
 pub struct Resetter {
     slot: u8,
@@ -16,14 +16,14 @@ impl Resetter {
     }
 
     fn start_resetting(&mut self) {
-        xhci::handle_registers(|r| {
+        registers::handle(|r| {
             r.port_register_set
                 .update_at((self.slot - 1).into(), |r| r.portsc.set_port_reset(true))
         });
     }
 
     fn wait_until_reset_is_completed(&self) {
-        xhci::handle_registers(|r| {
+        registers::handle(|r| {
             while !r
                 .port_register_set
                 .read_at((self.slot - 1).into())

--- a/kernel/src/device/pci/xhci/structures/context.rs
+++ b/kernel/src/device/pci/xhci/structures/context.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::ring::CycleBit;
-use crate::device::pci::xhci;
+use crate::device::pci::xhci::registers;
 use bit_field::BitField;
 use core::convert::{TryFrom, TryInto};
 use num_derive::FromPrimitive;
@@ -48,7 +48,7 @@ impl Input {
     }
 
     fn csz() -> bool {
-        xhci::handle_registers(|r| r.capability.hccparams1.read().context_size())
+        registers::handle(|r| r.capability.hccparams1.read().context_size())
     }
 }
 impl Default for Input {

--- a/kernel/src/device/pci/xhci/structures/dcbaa.rs
+++ b/kernel/src/device/pci/xhci/structures/dcbaa.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::device::pci::xhci;
+use super::registers;
 use conquer_once::spin::Lazy;
 use core::ops::{Index, IndexMut};
 use page_box::PageBox;
@@ -32,12 +32,11 @@ impl<'a> DeviceContextBaseAddressArray {
     }
 
     fn num_of_slots() -> usize {
-        xhci::handle_registers(|r| r.capability.hcsparams1.read().number_of_device_slots() + 1)
-            .into()
+        registers::handle(|r| r.capability.hcsparams1.read().number_of_device_slots() + 1).into()
     }
 
     fn register_address_to_xhci_register(&self) {
-        xhci::handle_registers(|r| {
+        registers::handle(|r| {
             r.operational.dcbaap.update(|d| {
                 d.set(self.phys_addr().as_u64()).expect(
                     "The Device Context Base Address Array Base Pointer is not aligned correctly.",

--- a/kernel/src/device/pci/xhci/structures/extended_capabilities.rs
+++ b/kernel/src/device/pci/xhci/structures/extended_capabilities.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use super::registers;
+use crate::mem::accessor::Mappers;
+use conquer_once::spin::OnceCell;
+use core::convert::TryInto;
+use spinning_top::Spinlock;
+use x86_64::PhysAddr;
+use xhci::{extended_capabilities, ExtendedCapability};
+
+static EXTENDED_CAPABILITIES: OnceCell<Spinlock<Option<extended_capabilities::List<Mappers>>>> =
+    OnceCell::uninit();
+
+pub(in crate::device::pci::xhci) fn init(mmio_base: PhysAddr) {
+    let hccparams1 = registers::handle(|r| r.capability.hccparams1.read());
+
+    EXTENDED_CAPABILITIES
+        .try_init_once(|| {
+            Spinlock::new(
+                // SAFETY: The address is the correct one and the Extended Capabilities are accessed only through
+                // this static.
+                unsafe {
+                    extended_capabilities::List::new(
+                        mmio_base.as_u64().try_into().unwrap(),
+                        hccparams1,
+                        Mappers::user(),
+                    )
+                },
+            )
+        })
+        .expect("Failed to initialize `EXTENDED_CAPABILITIES`.");
+}
+
+pub(in crate::device::pci::xhci) fn iter() -> Option<
+    impl Iterator<Item = Result<ExtendedCapability<Mappers>, extended_capabilities::NotSupportedId>>,
+> {
+    Some(
+        EXTENDED_CAPABILITIES
+            .try_get()
+            .expect("`EXTENDED_CAPABILITIES` is not initialized.`")
+            .lock()
+            .as_mut()?
+            .into_iter(),
+    )
+}

--- a/kernel/src/device/pci/xhci/structures/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/mod.rs
@@ -3,6 +3,7 @@
 pub mod context;
 pub mod dcbaa;
 pub mod descriptor;
+pub(super) mod extended_capabilities;
 pub(super) mod registers;
 pub mod ring;
 pub mod scratchpad;

--- a/kernel/src/device/pci/xhci/structures/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/mod.rs
@@ -3,5 +3,6 @@
 pub mod context;
 pub mod dcbaa;
 pub mod descriptor;
+pub(super) mod registers;
 pub mod ring;
 pub mod scratchpad;

--- a/kernel/src/device/pci/xhci/structures/registers.rs
+++ b/kernel/src/device/pci/xhci/structures/registers.rs
@@ -1,0 +1,1 @@
+// SPDX-License-Identifier: GPL-3.0-or-later

--- a/kernel/src/device/pci/xhci/structures/registers.rs
+++ b/kernel/src/device/pci/xhci/structures/registers.rs
@@ -1,1 +1,41 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::mem::accessor::Mappers;
+use conquer_once::spin::OnceCell;
+use core::convert::TryInto;
+use spinning_top::Spinlock;
+use x86_64::PhysAddr;
+use xhci::Registers;
+
+static REGISTERS: OnceCell<Spinlock<Registers<Mappers>>> = OnceCell::uninit();
+
+pub(in crate::device::pci::xhci) fn init(mmio_base: PhysAddr) {
+    REGISTERS
+        .try_init_once(|| {
+            Spinlock::new(
+                // SAFETY: The address is the correct one and the Registers are accessed only through
+                // this static.
+                unsafe {
+                    Registers::new(mmio_base.as_u64().try_into().unwrap(), Mappers::user())
+                        .expect("The MMIO base address of the xHC is not aligned correctly.")
+                },
+            )
+        })
+        .expect("Failed to initialize `REGISTERS`.")
+}
+
+/// Handle xHCI registers.
+///
+/// To avoid deadlocking, this method takes a closure. Caller is supposed not to call this method
+/// inside the closure, otherwise a deadlock will happen.
+///
+/// Alternative implementation is to define a method which returns `impl Deref<Target =
+/// Registers>`, but this will expand the scope of the mutex guard, increasing the possibility of
+/// deadlocks.
+pub(in crate::device::pci::xhci) fn handle<T, U>(f: T) -> U
+where
+    T: Fn(&mut Registers<Mappers>) -> U,
+{
+    let mut r = REGISTERS.try_get().unwrap().lock();
+    f(&mut r)
+}

--- a/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/command/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::{CycleBit, Link};
-use crate::device::pci::xhci;
+use crate::device::pci::xhci::registers;
 use page_box::PageBox;
 use trb::Trb;
 use x86_64::{
@@ -37,7 +37,7 @@ impl Ring {
     }
 
     fn notify_command_is_sent() {
-        xhci::handle_registers(|r| {
+        registers::handle(|r| {
             r.doorbell.update_at(0, |r| r.set_doorbell_target(0));
         })
     }
@@ -123,7 +123,7 @@ impl<'a> Initializer<'a> {
     }
 
     fn init(&mut self) {
-        xhci::handle_registers(|r| {
+        registers::handle(|r| {
             let a = self.ring.phys_addr();
 
             // Do not split this closure to avoid read-modify-write bug. Reading fields may return

--- a/kernel/src/device/pci/xhci/structures/ring/event/mod.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/event/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::CycleBit;
-use crate::device::pci::xhci::{self, exchanger::receiver, port};
+use crate::device::pci::xhci::{exchanger::receiver, port, structures::registers};
 use alloc::vec::Vec;
 use bit_field::BitField;
 use core::{
@@ -44,7 +44,7 @@ pub struct Ring {
 }
 impl<'a> Ring {
     pub fn new() -> Self {
-        let max_num_of_erst = xhci::handle_registers(|r| {
+        let max_num_of_erst = registers::handle(|r| {
             r.capability
                 .hcsparams2
                 .read()
@@ -123,7 +123,7 @@ impl Raw {
     }
 
     fn max_num_of_erst() -> u16 {
-        xhci::handle_registers(|r| {
+        registers::handle(|r| {
             r.capability
                 .hcsparams2
                 .read()
@@ -181,7 +181,7 @@ impl Raw {
     }
 
     fn update_deq_p_with_xhci(&self) {
-        xhci::handle_registers(|r| {
+        registers::handle(|r| {
             r.interrupt_register_set.update_at(0, |r| {
                 r.erdp
                     .set_event_ring_dequeue_pointer(self.next_trb_addr().as_u64())
@@ -221,7 +221,7 @@ impl<'a> SegTblInitializer<'a> {
     }
 
     fn register_tbl_sz(&mut self) {
-        xhci::handle_registers(|r| {
+        registers::handle(|r| {
             let l = self.tbl_len();
 
             r.interrupt_register_set
@@ -230,7 +230,7 @@ impl<'a> SegTblInitializer<'a> {
     }
 
     fn enable_event_ring(&mut self) {
-        xhci::handle_registers(|r| {
+        registers::handle(|r| {
             let a = self.tbl_addr();
             r.interrupt_register_set.update_at(0, |r| {
                 r.erstba

--- a/kernel/src/device/pci/xhci/structures/scratchpad.rs
+++ b/kernel/src/device/pci/xhci/structures/scratchpad.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::dcbaa;
-use crate::device::pci::xhci;
+use crate::device::pci::xhci::registers;
 use alloc::vec::Vec;
 use conquer_once::spin::OnceCell;
 use core::convert::TryInto;
@@ -69,10 +69,10 @@ impl Scratchpad {
     }
 
     fn num_of_buffers() -> u32 {
-        xhci::handle_registers(|r| r.capability.hcsparams2.read().max_scratchpad_buffers())
+        registers::handle(|r| r.capability.hcsparams2.read().max_scratchpad_buffers())
     }
 
     fn page_size() -> Bytes {
-        Bytes::new(xhci::handle_registers(|r| r.operational.pagesize.read().get()).into())
+        Bytes::new(registers::handle(|r| r.operational.pagesize.read().get()).into())
     }
 }

--- a/kernel/src/device/pci/xhci/xhc.rs
+++ b/kernel/src/device/pci/xhci/xhc.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use super::structures::registers;
+use super::structures::{extended_capabilities, registers};
 use xhci::extended_capabilities::ExtendedCapability;
 
 pub fn init() {
@@ -30,7 +30,7 @@ pub fn ensure_no_error_occurs() {
 }
 
 fn get_ownership_from_bios() {
-    if let Some(iter) = super::iter_extended_capabilities() {
+    if let Some(iter) = extended_capabilities::iter() {
         for c in iter.filter_map(Result::ok) {
             if let ExtendedCapability::UsbLegacySupportCapability(mut l) = c {
                 l.update(|s| s.set_hc_os_owned_semaphore(true));


### PR DESCRIPTION
- chore: add `registers.rs`
- chore: move codes to the `register` module

bors r+
