### PR TITLE
chore: replace `merge_imports` with `imports_granularity`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 edition = "2018"
-merge_imports = true
+imports_granularity = "Crate"


### PR DESCRIPTION
bors r+
