### PR TITLE
chore: remove the unused interrupt handlers

### DIFF
--- a/kernel/src/interrupt/handler.rs
+++ b/kernel/src/interrupt/handler.rs
@@ -7,78 +7,6 @@ use crate::{
 };
 use common::constant::{INTERRUPT_STACK, PORT_KEY_DATA};
 
-pub extern "x86-interrupt" fn h_00(
-    _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
-) {
-    panic!("Divide-by-zero Error!");
-}
-
-pub extern "x86-interrupt" fn h_01(
-    _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
-) {
-    panic!("Debug exception!");
-}
-
-pub extern "x86-interrupt" fn h_02(
-    _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
-) {
-    panic!("Non-maskable Interrupt!");
-}
-
-pub extern "x86-interrupt" fn h_03(
-    _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
-) {
-    panic!("Breakpoint!");
-}
-
-pub extern "x86-interrupt" fn h_04(
-    _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
-) {
-    panic!("Overflow!");
-}
-
-pub extern "x86-interrupt" fn h_05(
-    _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
-) {
-    panic!("Bound Range Exceeded!");
-}
-
-pub extern "x86-interrupt" fn h_06(
-    _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
-) {
-    panic!("Invalid Opcode!");
-}
-
-pub extern "x86-interrupt" fn h_07(
-    _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
-) {
-    panic!("Device Not Available!");
-}
-
-pub extern "x86-interrupt" fn h_09(
-    _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
-) {
-    panic!("Coprocessor Segment Overrun!");
-}
-
-pub extern "x86-interrupt" fn h_10(
-    _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
-) {
-    panic!("x87 Floating-Point Exception");
-}
-
-pub extern "x86-interrupt" fn h_13(
-    _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
-) {
-    panic!("SIMD Floating-Point Exception");
-}
-
-pub extern "x86-interrupt" fn h_14(
-    _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
-) {
-    panic!("Virtualization Exception!");
-}
-
 pub extern "x86-interrupt" fn h_20(
     _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
 ) {
@@ -112,10 +40,4 @@ pub extern "x86-interrupt" fn h_2c(
     apic::local::end_of_interrupt();
     let mut port = PORT_KEY_DATA;
     mouse::enqueue_packet(unsafe { port.read() });
-}
-
-pub extern "x86-interrupt" fn h_40(
-    _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
-) {
-    info!("Interrupt from 0x40");
 }

--- a/kernel/src/interrupt/idt.rs
+++ b/kernel/src/interrupt/idt.rs
@@ -7,18 +7,6 @@ use conquer_once::spin::Lazy;
 
 static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     let mut idt = InterruptDescriptorTable::new();
-    idt[0x00].set_handler_fn(interrupt::handler::h_00);
-    idt[0x01].set_handler_fn(interrupt::handler::h_01);
-    idt[0x02].set_handler_fn(interrupt::handler::h_02);
-    idt[0x03].set_handler_fn(interrupt::handler::h_03);
-    idt[0x04].set_handler_fn(interrupt::handler::h_04);
-    idt[0x05].set_handler_fn(interrupt::handler::h_05);
-    idt[0x06].set_handler_fn(interrupt::handler::h_06);
-    idt[0x07].set_handler_fn(interrupt::handler::h_07);
-    idt[0x09].set_handler_fn(interrupt::handler::h_09);
-    idt[0x10].set_handler_fn(interrupt::handler::h_10);
-    idt[0x13].set_handler_fn(interrupt::handler::h_13);
-    idt[0x14].set_handler_fn(interrupt::handler::h_14);
 
     // SAFETY: This operation is safe as the stack index 0 is allocated for the timer
     // interruption.
@@ -29,7 +17,6 @@ static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     }
     idt[0x21].set_handler_fn(interrupt::handler::h_21);
     idt[0x2c].set_handler_fn(interrupt::handler::h_2c);
-    idt[0x40].set_handler_fn(interrupt::handler::h_40);
 
     idt
 });


### PR DESCRIPTION
Stopping QEMU by the unhandled interrupts is easier to debug.

bors r+
