### PR TITLE
chore: use system calls to access the I/O ports

### DIFF
--- a/common/src/constant.rs
+++ b/common/src/constant.rs
@@ -2,7 +2,6 @@
 
 use os_units::{Bytes, NumOfPages};
 use x86_64::{
-    instructions::port::Port,
     structures::paging::{PageSize, Size4KiB},
     PhysAddr, VirtAddr,
 };
@@ -26,9 +25,9 @@ pub const NUM_OF_PAGES_STACK: NumOfPages<Size4KiB> = NumOfPages::new(16);
 pub const BYTES_KERNEL_HEAP: Bytes = Bytes::new(0x1000_0000);
 pub const BYTES_AVAILABLE_RAM: Bytes = Bytes::new(0x1_0000_0000_0000);
 
-pub const PORT_KEY_STATUS: Port<u8> = Port::new(0x0064);
-pub const PORT_KEY_CMD: Port<u8> = Port::new(0x0064);
-pub const PORT_KEY_DATA: Port<u8> = Port::new(0x0060);
+pub const PORT_KEY_STATUS: u16 = 0x0064;
+pub const PORT_KEY_CMD: u16 = 0x0064;
+pub const PORT_KEY_DATA: u16 = 0x0060;
 
 pub const KEY_CMD_WRITE_MODE: u8 = 0x60;
 pub const KEY_CMD_MODE: u8 = 0x47;

--- a/kernel/src/device/keyboard.rs
+++ b/kernel/src/device/keyboard.rs
@@ -72,19 +72,19 @@ impl Stream for ScancodeStream {
 fn enable_keyboard() {
     wait_kbc_sendready();
 
-    let mut port_key_cmd = PORT_KEY_CMD;
-    unsafe { port_key_cmd.write(KEY_CMD_WRITE_MODE as u8) };
+    let port_key_cmd = PORT_KEY_CMD;
+    unsafe { syscalls::outb(port_key_cmd, KEY_CMD_WRITE_MODE as u8) };
 
     wait_kbc_sendready();
 
-    let mut port_key_data = PORT_KEY_DATA;
-    unsafe { port_key_data.write(KEY_CMD_MODE as u8) };
+    let port_key_data = PORT_KEY_DATA;
+    unsafe { syscalls::outb(port_key_data, KEY_CMD_MODE as u8) };
 }
 
 pub(super) fn wait_kbc_sendready() {
     loop {
-        let mut port_key_status = PORT_KEY_STATUS;
-        if unsafe { port_key_status.read() } & KEY_STATUS_SEND_NOT_READY == 0 {
+        let port_key_status = PORT_KEY_STATUS;
+        if unsafe { syscalls::inb(port_key_status) } & KEY_STATUS_SEND_NOT_READY == 0 {
             break;
         }
     }

--- a/kernel/src/device/mouse.rs
+++ b/kernel/src/device/mouse.rs
@@ -75,13 +75,13 @@ impl Device {
     fn enable() {
         super::keyboard::wait_kbc_sendready();
 
-        let mut port_key_cmd = PORT_KEY_CMD;
-        unsafe { port_key_cmd.write(KEY_CMD_SEND_TO_MOUSE) };
+        let port_key_cmd = PORT_KEY_CMD;
+        unsafe { syscalls::outb(port_key_cmd, KEY_CMD_SEND_TO_MOUSE) };
 
         super::keyboard::wait_kbc_sendready();
 
-        let mut port_key_data = PORT_KEY_DATA;
-        unsafe { port_key_data.write(MOUSE_CMD_ENABLE) };
+        let port_key_data = PORT_KEY_DATA;
+        unsafe { syscalls::outb(port_key_data, MOUSE_CMD_ENABLE) };
     }
 
     fn three_packets_available(&self) -> bool {

--- a/kernel/src/interrupt/handler.rs
+++ b/kernel/src/interrupt/handler.rs
@@ -8,6 +8,7 @@ use crate::{
 use alloc::{collections::BTreeMap, vec::Vec};
 use common::constant::{INTERRUPT_STACK, PORT_KEY_DATA};
 use spinning_top::Spinlock;
+use x86_64::instructions::port::PortReadOnly;
 
 static NOTIFY_ON_INTERRUPT: Spinlock<BTreeMap<usize, Vec<i32>>> = Spinlock::new(BTreeMap::new());
 
@@ -34,7 +35,7 @@ pub extern "x86-interrupt" fn h_21(
     _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
 ) {
     apic::local::end_of_interrupt();
-    let mut port = PORT_KEY_DATA;
+    let mut port = PortReadOnly::new(PORT_KEY_DATA);
     keyboard::enqueue_scancode(unsafe { port.read() });
 }
 
@@ -42,7 +43,7 @@ pub extern "x86-interrupt" fn h_2c(
     _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
 ) {
     apic::local::end_of_interrupt();
-    let mut port = PORT_KEY_DATA;
+    let mut port = PortReadOnly::new(PORT_KEY_DATA);
     mouse::enqueue_packet(unsafe { port.read() });
 }
 

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -13,6 +13,7 @@ use x86_64::{structures::paging::Size4KiB, PhysAddr, VirtAddr};
 ///
 /// This function is unsafe because reading a value from I/O port may have side effects which
 /// violate memory safety.
+#[must_use]
 pub unsafe fn inb(port: u16) -> u8 {
     general_syscall(Ty::Inb, port.into(), 0, 0)
         .try_into()

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -11,6 +11,16 @@ use x86_64::{structures::paging::Size4KiB, PhysAddr, VirtAddr};
 
 /// # Safety
 ///
+/// This function is unsafe because reading a value from I/O port may have side effects which
+/// violate memory safety.
+pub unsafe fn inb(port: u16) -> u8 {
+    general_syscall(Ty::Inb, port.into(), 0, 0)
+        .try_into()
+        .unwrap()
+}
+
+/// # Safety
+///
 /// This function is unsafe because reading a value from I/O port may have side effects which violate memory safety.
 #[must_use]
 pub unsafe fn inl(port: u16) -> u32 {
@@ -19,6 +29,14 @@ pub unsafe fn inl(port: u16) -> u32 {
         .unwrap_or_else(|_| {
             unreachable!("Inl system call returns a value which is out of the ramge of `u32`.")
         })
+}
+
+/// # Safety
+///
+/// This function is unsafe because writing a value from I/O port may have side effects which
+/// violate memory safety.
+pub unsafe fn outb(port: u16, value: u8) {
+    general_syscall(Ty::Outb, port.into(), value.into(), 0);
 }
 
 /// # Safety


### PR DESCRIPTION
I can't figure out why the keyboard driver and the mouse driver could
access without the system calls.

bors r+
