### PR TITLE
refactor: use the safe way to convert a file handler

### DIFF
--- a/bootx64/src/fs/mod.rs
+++ b/bootx64/src/fs/mod.rs
@@ -71,12 +71,12 @@ pub fn fetch_entry_address_and_memory_size(addr: PhysAddr, bytes: Bytes) -> (Vir
     }
 }
 
-fn get_handler(root_dir: &mut file::Directory, name: &'static str) -> file::RegularFile {
-    let handler = root_dir
+fn get_handler(root: &mut file::Directory, name: &'static str) -> file::RegularFile {
+    let h = root
         .open(name, FileMode::Read, FileAttribute::empty())
         .expect_success("Failed to get file handler of the kernel.");
 
-    unsafe { file::RegularFile::new(handler) }
+    unsafe { file::RegularFile::new(h) }
 }
 
 fn allocate(boot_services: &boot::BootServices, kernel_bytes: Bytes) -> PhysAddr {

--- a/bootx64/src/fs/mod.rs
+++ b/bootx64/src/fs/mod.rs
@@ -8,7 +8,7 @@ use core::{
     slice,
 };
 use elf_rs::Elf;
-use file::RegularFile;
+use file::{FileType, RegularFile};
 use os_units::Bytes;
 use uefi::{
     proto::media::{
@@ -76,7 +76,16 @@ fn get_handler(root: &mut file::Directory, name: &'static str) -> file::RegularF
         .open(name, FileMode::Read, FileAttribute::empty())
         .expect_success("Failed to get file handler of the kernel.");
 
-    unsafe { file::RegularFile::new(h) }
+    let h = h
+        .into_type()
+        .expect_success("Failed to get the type of a file.");
+
+    match h {
+        FileType::Regular(r) => r,
+        FileType::Dir(_) => {
+            panic!("Not a regular file.")
+        }
+    }
 }
 
 fn allocate(boot_services: &boot::BootServices, kernel_bytes: Bytes) -> PhysAddr {


### PR DESCRIPTION
- refactor: shorten the variable names
- refactor: use a safe way to generate the `RegularFile`

bors r+
