### PR TITLE
chore: minimize the size of the `initialize_in_user_mode` function

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -59,7 +59,7 @@ pub extern "win64" fn os_main(mut boot_info: kernelboot::Info) -> ! {
 
 fn init(boot_info: &mut kernelboot::Info) {
     initialize_in_kernel_mode(boot_info);
-    initialize_in_user_mode(boot_info);
+    initialize_in_user_mode();
 }
 
 fn initialize_in_kernel_mode(boot_info: &mut kernelboot::Info) {
@@ -78,18 +78,20 @@ fn initialize_in_kernel_mode(boot_info: &mut kernelboot::Info) {
     apic::io::init(&acpi);
 
     timer::init(&acpi);
-}
-
-fn initialize_in_user_mode(boot_info: &mut kernelboot::Info) {
-    syscall::init();
-    gdt::enter_usermode();
 
     vram::init(&boot_info);
 
     terminal::log::init().unwrap();
 
     info!("Hello Ramen OS!");
+
     vram::print_info();
+
+    syscall::init();
+}
+
+fn initialize_in_user_mode() {
+    gdt::enter_usermode();
 
     process::manager::init();
     add_processes();


### PR DESCRIPTION
Eventually calling a system call will be to send a message. This needs
processes to exist, but before creating them system calls cannot be
called. Ultimately this function should be removed.

bors r+
