### PR TITLE
chore: use the privilege stack table, instead of the interrupt one

### DIFF
--- a/kernel/src/interrupt/idt.rs
+++ b/kernel/src/interrupt/idt.rs
@@ -8,13 +8,7 @@ use conquer_once::spin::Lazy;
 static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     let mut idt = InterruptDescriptorTable::new();
 
-    // SAFETY: This operation is safe as the stack index 0 is allocated for the timer
-    // interruption.
-    unsafe {
-        idt[0x20]
-            .set_handler_fn(interrupt::handler::h_20)
-            .set_stack_index(0);
-    }
+    idt[0x20].set_handler_fn(interrupt::handler::h_20);
     idt[0x21].set_handler_fn(interrupt::handler::h_21);
     idt[0x2c].set_handler_fn(interrupt::handler::h_2c);
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -89,7 +89,6 @@ fn initialize_in_kernel_mode(boot_info: &mut kernelboot::Info) {
 
     syscall::init();
 
-    process::init();
     add_processes();
 }
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -23,12 +23,8 @@ use x86_64::{
 
 use crate::{mem::allocator::kpbox::KpBox, tss::TSS};
 
-pub(super) fn init() {
-    set_temporary_stack_frame();
-}
-
 fn set_temporary_stack_frame() {
-    TSS.lock().interrupt_stack_table[0] = INTERRUPT_STACK;
+    TSS.lock().privilege_stack_table[0] = INTERRUPT_STACK;
 }
 
 #[derive(Debug)]

--- a/kernel/src/process/switch.rs
+++ b/kernel/src/process/switch.rs
@@ -32,7 +32,7 @@ fn switch_pml4() {
 }
 
 fn register_current_stack_frame_with_tss() {
-    TSS.lock().interrupt_stack_table[0] = current_stack_frame_bottom_addr();
+    TSS.lock().privilege_stack_table[0] = current_stack_frame_bottom_addr();
 }
 
 fn current_stack_frame_top_addr() -> VirtAddr {


### PR DESCRIPTION
Eventually, interrupts will be handled by the common mechanism.

bors r+
