### PR TITLE
chore: remove the system calls which handle interrupts

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -55,7 +55,7 @@ pub type FuturelockGuard<'a, T> = GenericMutexGuard<'a, RawSpinlock, T>;
 #[start]
 pub extern "win64" fn os_main(mut boot_info: kernelboot::Info) -> ! {
     init(&mut boot_info);
-    wait_until_timer_interrupt_happens();
+    cause_timer_interrupt();
 }
 
 fn init(boot_info: &mut kernelboot::Info) {
@@ -106,10 +106,9 @@ fn add_processes() {
     }
 }
 
-fn wait_until_timer_interrupt_happens() -> ! {
-    loop {
-        syscalls::enable_interrupt_and_halt()
-    }
+fn cause_timer_interrupt() -> ! {
+    // SAFETY: This interrupt is handled correctly.
+    unsafe { asm!("int 0x20", options(noreturn)) }
 }
 
 fn run_tasks() {

--- a/kernel/src/multitask/executor.rs
+++ b/kernel/src/multitask/executor.rs
@@ -27,16 +27,6 @@ impl Executor {
     pub fn run(&mut self) -> ! {
         loop {
             self.run_woken_tasks();
-            Self::sleep_if_idle();
-        }
-    }
-
-    fn sleep_if_idle() {
-        syscalls::disable_interrupt();
-        if task::COLLECTION.lock().woken_task_exists() {
-            syscalls::enable_interrupt();
-        } else {
-            syscalls::enable_interrupt_and_halt();
         }
     }
 

--- a/kernel/src/multitask/task.rs
+++ b/kernel/src/multitask/task.rs
@@ -57,10 +57,6 @@ impl Collection {
             .expect("Woken task id queue is full.");
     }
 
-    pub fn woken_task_exists(&self) -> bool {
-        !self.woken_task_ids.is_empty()
-    }
-
     pub fn pop_woken_task_id(&mut self) -> Option<Id> {
         self.woken_task_ids.pop()
     }

--- a/kernel/src/panic.rs
+++ b/kernel/src/panic.rs
@@ -4,7 +4,6 @@ use crate::qemu;
 
 #[panic_handler]
 fn panic(i: &core::panic::PanicInfo) -> ! {
-    syscalls::disable_interrupt();
     print_banner();
     print_info(i);
 
@@ -26,7 +25,7 @@ fn fini() -> ! {
         qemu::exit_failure();
     } else {
         loop {
-            syscalls::halt()
+            x86_64::instructions::nop();
         }
     }
 }

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -8,10 +8,7 @@ use core::{convert::TryInto, ffi::c_void, slice};
 use num_traits::FromPrimitive;
 use os_units::{Bytes, NumOfPages};
 use x86_64::{
-    instructions::{
-        self, interrupts,
-        port::{PortReadOnly, PortWriteOnly},
-    },
+    instructions::port::{PortReadOnly, PortWriteOnly},
     registers::model_specific::{Efer, EferFlags, LStar},
     structures::paging::{Size4KiB, Translate},
     PhysAddr, VirtAddr,
@@ -82,10 +79,6 @@ unsafe fn select_proper_syscall(idx: u64, a1: u64, a2: u64, a3: u64) -> u64 {
             syscalls::Ty::Outb => sys_outb(a1.try_into().unwrap(), a2.try_into().unwrap()),
             syscalls::Ty::Inl => sys_inl(a1.try_into().unwrap()).into(),
             syscalls::Ty::Outl => sys_outl(a1.try_into().unwrap(), a2.try_into().unwrap()),
-            syscalls::Ty::Halt => sys_halt(),
-            syscalls::Ty::DisableInterrupt => sys_disable_interrupt(),
-            syscalls::Ty::EnableInterrupt => sys_enable_interrupt(),
-            syscalls::Ty::EnableInterruptAndHalt => sys_enable_interrupt_and_halt(),
             syscalls::Ty::AllocatePages => {
                 sys_allocate_pages(NumOfPages::new(a1.try_into().unwrap())).as_u64()
             }
@@ -140,26 +133,6 @@ unsafe fn sys_inl(port: u16) -> u32 {
 unsafe fn sys_outl(port: u16, v: u32) -> u64 {
     let mut p = PortWriteOnly::new(port);
     p.write(v);
-    0
-}
-
-fn sys_halt() -> u64 {
-    instructions::hlt();
-    0
-}
-
-fn sys_disable_interrupt() -> u64 {
-    interrupts::disable();
-    0
-}
-
-fn sys_enable_interrupt() -> u64 {
-    interrupts::enable();
-    0
-}
-
-fn sys_enable_interrupt_and_halt() -> u64 {
-    interrupts::enable_and_hlt();
     0
 }
 

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -48,26 +48,6 @@ pub unsafe fn outl(port: u16, value: u32) {
     general_syscall(Ty::Outl, port.into(), value.into(), 0);
 }
 
-pub fn halt() {
-    // SAFETY: This operation is safe as it does not touch any unsafe things.
-    unsafe { general_syscall(Ty::Halt, 0, 0, 0) };
-}
-
-pub fn disable_interrupt() {
-    // SAFETY: This operation is safe as it does not touch any unsafe things.
-    unsafe { general_syscall(Ty::DisableInterrupt, 0, 0, 0) };
-}
-
-pub fn enable_interrupt() {
-    // SAFETY: This operation is safe as it does not touch any unsafe things.
-    unsafe { general_syscall(Ty::EnableInterrupt, 0, 0, 0) };
-}
-
-pub fn enable_interrupt_and_halt() {
-    // SAFETY: This operation is safe as it does not touch any unsafe things.
-    unsafe { general_syscall(Ty::EnableInterruptAndHalt, 0, 0, 0) };
-}
-
 #[must_use]
 pub fn allocate_pages(pages: NumOfPages<Size4KiB>) -> VirtAddr {
     // SAFETY: This operation is safe as the arguments are propertly passed.
@@ -184,10 +164,6 @@ pub enum Ty {
     Outb,
     Inl,
     Outl,
-    Halt,
-    DisableInterrupt,
-    EnableInterrupt,
-    EnableInterruptAndHalt,
     AllocatePages,
     DeallocatePages,
     MapPages,


### PR DESCRIPTION
The user process should not modify interrupt settings. For example, if
the timer interrupts are disabled, process switch will no longer happen.

bors r+
