### PR TITLE
chore: use interrupts to call system calls

### DIFF
--- a/kernel/src/interrupt/handler.rs
+++ b/kernel/src/interrupt/handler.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::apic;
-use crate::process;
+use crate::{process, syscall};
 use common::constant::INTERRUPT_STACK;
 
 pub extern "x86-interrupt" fn h_20(
@@ -20,5 +20,26 @@ pub extern "x86-interrupt" fn h_20(
             call {}
             mov rsp, rax
         ", const INTERRUPT_STACK.as_u64(), sym apic::local::end_of_interrupt, sym process::manager::switch, out("rax") _, out("rbx") _, out("rcx") _, out("rdx") _, out("rsi") _, out("rdi") _,  out("r8") _, out("r9") _, out("r10") _, out("r11") _, out("r12") _, out("r13") _, out("r14") _, out("r15") _);
+    }
+}
+
+pub extern "x86-interrupt" fn h_80(
+    _stack_frame: &mut x86_64::structures::idt::InterruptStackFrame,
+) {
+    // Here, the stack pointer points the stack frame of the current task. By cloberring registers,
+    // the state will be stored on the stack frame.
+    //
+    // SAFETY: This operation is safe. After calling the `switch` function, `rax` contains the address to the top of the stack frame of
+    // the new process. It does not violate any memory safety.
+    unsafe {
+        asm!(
+            "
+            mov rsp, {}
+            call {}
+            call {}
+            call {}
+            call {}
+            mov rsp, rax
+        ", const INTERRUPT_STACK.as_u64(), sym syscall::prepare_arguments, sym process::assign_rax_from_register, sym apic::local::end_of_interrupt, sym process::manager::switch, out("rax") _, out("rbx") _, out("rcx") _, out("rdx") _, out("rsi") _, out("rdi") _,  out("r8") _, out("r9") _, out("r10") _, out("r11") _, out("r12") _, out("r13") _, out("r14") _, out("r15") _);
     }
 }

--- a/kernel/src/interrupt/idt.rs
+++ b/kernel/src/interrupt/idt.rs
@@ -4,11 +4,15 @@
 
 use crate::{interrupt, x86_64::structures::idt::InterruptDescriptorTable};
 use conquer_once::spin::Lazy;
+use x86_64::PrivilegeLevel;
 
 static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     let mut idt = InterruptDescriptorTable::new();
 
     idt[0x20].set_handler_fn(interrupt::handler::h_20);
+    idt[0x80]
+        .set_handler_fn(interrupt::handler::h_80)
+        .set_privilege_level(PrivilegeLevel::Ring3);
 
     idt
 });

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -87,8 +87,6 @@ fn initialize_in_kernel_mode(boot_info: &mut kernelboot::Info) {
 
     vram::print_info();
 
-    syscall::init();
-
     add_processes();
 }
 

--- a/kernel/src/process/collections/process.rs
+++ b/kernel/src/process/collections/process.rs
@@ -15,6 +15,25 @@ pub(in crate::process) fn add(p: Process) {
         .expect_none("Duplicated process.");
 }
 
+pub(in crate::process) fn handle_running_mut<T, U>(f: T) -> U
+where
+    T: FnOnce(&mut Process) -> U,
+{
+    let id = woken_pid::active_pid();
+    handle_mut(id, f)
+}
+
+pub(in crate::process) fn handle_mut<T, U>(id: process::Id, f: T) -> U
+where
+    T: FnOnce(&mut Process) -> U,
+{
+    let mut l = lock_processes();
+    let p = l
+        .get_mut(&id)
+        .unwrap_or_else(|| panic!("Process of PID {} does not exist.", id.as_i32()));
+    f(p)
+}
+
 pub(in crate::process) fn handle_running<T, U>(f: T) -> U
 where
     T: FnOnce(&Process) -> U,

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -23,6 +23,17 @@ use x86_64::{
 
 use crate::{mem::allocator::kpbox::KpBox, tss::TSS};
 
+pub(crate) fn assign_rax_from_register() {
+    let rax;
+    unsafe { asm!("", out("rax") rax) }
+
+    assign_rax(rax);
+}
+
+fn assign_rax(rax: u64) {
+    collections::process::handle_running_mut(|p| (*p.stack_frame).regs.rax = rax);
+}
+
 fn set_temporary_stack_frame() {
     TSS.lock().privilege_stack_table[0] = INTERRUPT_STACK;
 }

--- a/kernel/src/process/stack_frame.rs
+++ b/kernel/src/process/stack_frame.rs
@@ -12,8 +12,8 @@ use x86_64::{
 
 #[repr(C)]
 #[derive(Debug)]
-pub struct StackFrame {
-    regs: GeneralRegisters,
+pub(super) struct StackFrame {
+    pub(super) regs: GeneralRegisters,
     interrupt: InterruptStackFrameValue,
 }
 impl StackFrame {
@@ -63,8 +63,8 @@ impl Selectors {
 
 #[repr(C)]
 #[derive(Default, Debug)]
-struct GeneralRegisters {
-    _rax: u64,
+pub(super) struct GeneralRegisters {
+    pub(super) rax: u64,
     _rbx: u64,
     _rcx: u64,
     _rdx: u64,

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -121,7 +121,7 @@ pub fn getpid() -> i32 {
 
 pub fn exit() -> ! {
     let ty = Ty::Exit as u64;
-    unsafe { asm!("syscall", in("rax") ty, options(noreturn)) }
+    unsafe { asm!("int 0x80", in("rax") ty, options(noreturn)) }
 }
 
 /// This method will return a null address if the address is not mapped.
@@ -152,7 +152,7 @@ pub unsafe fn write(fildes: i32, buf: *const c_void, nbyte: u32) -> i32 {
 unsafe fn general_syscall(ty: Ty, a1: u64, a2: u64, a3: u64) -> u64 {
     let ty = ty as u64;
     let r: u64;
-    asm!("syscall",
+    asm!("int 0x80",
         inout("rax") ty => r, inout("rdi") a1 => _, inout("rsi") a2 => _, inout("rdx") a3 => _,
         out("rcx") _, out("r8") _, out("r9") _, out("r10") _, out("r11") _,);
     r


### PR DESCRIPTION
This makes it easier to save registers because the `RSP` is changed on
interrupt.

bors r+
