### PR TITLE
test: halve the count goal

### DIFF
--- a/kernel/src/tests/process.rs
+++ b/kernel/src/tests/process.rs
@@ -5,7 +5,7 @@ use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 pub static SWITCH_TEST_SUCCESS: AtomicBool = AtomicBool::new(false);
 
 pub fn count_switch() {
-    const EXIT_GOAL: usize = 1000;
+    const EXIT_GOAL: usize = 500;
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     COUNTER.fetch_add(1, Ordering::Relaxed);
 


### PR DESCRIPTION
500 is enough. Every process including the test processes will be
switched 4 or 5 times.

bors r+
