### PR TITLE
chore: use the interrupt stack table

### DIFF
--- a/kernel/src/interrupt/idt.rs
+++ b/kernel/src/interrupt/idt.rs
@@ -9,10 +9,16 @@ use x86_64::PrivilegeLevel;
 static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     let mut idt = InterruptDescriptorTable::new();
 
-    idt[0x20].set_handler_fn(interrupt::handler::h_20);
-    idt[0x80]
-        .set_handler_fn(interrupt::handler::h_80)
-        .set_privilege_level(PrivilegeLevel::Ring3);
+    // SAFETY: Nested interrupts are not allowed.
+    unsafe {
+        idt[0x20]
+            .set_handler_fn(interrupt::handler::h_20)
+            .set_stack_index(0);
+        idt[0x80]
+            .set_handler_fn(interrupt::handler::h_80)
+            .set_stack_index(0)
+            .set_privilege_level(PrivilegeLevel::Ring3);
+    }
 
     idt
 });

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -61,7 +61,7 @@ fn assign_rax(rax: u64) {
 }
 
 fn set_temporary_stack_frame() {
-    TSS.lock().privilege_stack_table[0] = INTERRUPT_STACK;
+    TSS.lock().interrupt_stack_table[0] = INTERRUPT_STACK;
 }
 
 #[derive(Debug)]

--- a/kernel/src/process/switch.rs
+++ b/kernel/src/process/switch.rs
@@ -32,7 +32,7 @@ fn switch_pml4() {
 }
 
 fn register_current_stack_frame_with_tss() {
-    TSS.lock().privilege_stack_table[0] = current_stack_frame_bottom_addr();
+    TSS.lock().interrupt_stack_table[0] = current_stack_frame_bottom_addr();
 }
 
 fn current_stack_frame_top_addr() -> VirtAddr {

--- a/kernel/src/tss.rs
+++ b/kernel/src/tss.rs
@@ -6,6 +6,6 @@ use x86_64::structures::tss::TaskStateSegment;
 
 pub static TSS: Spinlock<TaskStateSegment> = {
     let mut tss = TaskStateSegment::new();
-    tss.privilege_stack_table[0] = INTERRUPT_STACK;
+    tss.interrupt_stack_table[0] = INTERRUPT_STACK;
     Spinlock::new(tss)
 };


### PR DESCRIPTION
`RSP` will not be set to the right position of the stack frame if the
privilege stack table is used and an interrupt happens during the
kernel privilege process.

bors r+
