### PR TITLE
chore: write to the USB mass storage device after reading it

### DIFF
--- a/kernel/src/device/pci/xhci/port/class_driver/mass_storage/mod.rs
+++ b/kernel/src/device/pci/xhci/port/class_driver/mass_storage/mod.rs
@@ -27,9 +27,10 @@ pub(in crate::device::pci::xhci::port) async fn task(eps: FullyOperational) {
     let b = m.read_capacity().await;
     info!("Read Capacity: {:?}", b);
 
-    m.write10().await;
     let b = m.read10().await;
     info!("Buf: {:X?}", b);
+
+    m.write10().await;
 }
 
 struct MassStorage {


### PR DESCRIPTION
The ideal is to remove the code which writes to the device, but for the
future use, I have decided not to remove it.

bors r+
