### PR TITLE
refactor: move the definitions of CDB to the proper module

### DIFF
--- a/kernel/src/device/pci/xhci/port/class_driver/mass_storage/mod.rs
+++ b/kernel/src/device/pci/xhci/port/class_driver/mass_storage/mod.rs
@@ -9,8 +9,9 @@ use crate::device::pci::xhci::{
 use alloc::vec::Vec;
 use page_box::PageBox;
 use scsi::{
+    command_data_block::CommandDataBlock,
     response::{Inquiry, Read10, ReadCapacity},
-    CommandBlockWrapper, CommandBlockWrapperHeaderBuilder, CommandDataBlock, CommandStatusWrapper,
+    CommandBlockWrapper, CommandBlockWrapperHeaderBuilder, CommandStatusWrapper,
 };
 use xhci::context::EndpointType;
 

--- a/kernel/src/device/pci/xhci/port/class_driver/mass_storage/scsi/command_data_block.rs
+++ b/kernel/src/device/pci/xhci/port/class_driver/mass_storage/scsi/command_data_block.rs
@@ -1,0 +1,1 @@
+// SPDX-License-Identifier: GPL-3.0-or-later

--- a/kernel/src/device/pci/xhci/port/class_driver/mass_storage/scsi/command_data_block.rs
+++ b/kernel/src/device/pci/xhci/port/class_driver/mass_storage/scsi/command_data_block.rs
@@ -1,1 +1,50 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#[repr(transparent)]
+#[derive(Default)]
+pub(in super::super) struct CommandDataBlock([u8; 16]);
+impl CommandDataBlock {
+    pub(in super::super) fn inquiry() -> Self {
+        let mut b = Self::default();
+        b.set_command(Command::Inquiry);
+        b.0[4] = 0x24;
+        b
+    }
+
+    pub(in super::super) fn read_capacity() -> Self {
+        let mut b = Self::default();
+        b.set_command(Command::ReadCapacity);
+        b
+    }
+
+    pub(in super::super) fn read10() -> Self {
+        let mut b = Self::default();
+        b.set_command(Command::Read10);
+        b.0[8] = 0x40;
+        b
+    }
+
+    pub(in super::super) fn write10() -> Self {
+        let mut b = Self::default();
+        b.set_command(Command::Write10);
+        b.0[8] = 0x40;
+        b
+    }
+
+    fn set_command(&mut self, c: Command) {
+        self.0[0] = c.into();
+    }
+}
+
+#[repr(u8)]
+enum Command {
+    Inquiry = 0x12,
+    ReadCapacity = 0x25,
+    Read10 = 0x28,
+    Write10 = 0x2a,
+}
+impl From<Command> for u8 {
+    fn from(c: Command) -> Self {
+        c as u8
+    }
+}

--- a/kernel/src/device/pci/xhci/port/class_driver/mass_storage/scsi/mod.rs
+++ b/kernel/src/device/pci/xhci/port/class_driver/mass_storage/scsi/mod.rs
@@ -3,6 +3,7 @@
 pub(super) mod command_data_block;
 pub(super) mod response;
 
+use command_data_block::CommandDataBlock;
 use num_derive::FromPrimitive;
 
 #[repr(C, packed)]
@@ -31,55 +32,6 @@ pub(super) struct CommandBlockWrapperHeader {
 }
 impl CommandBlockWrapperHeader {
     const SIGNATURE: u32 = 0x4342_5355;
-}
-
-#[repr(transparent)]
-#[derive(Default)]
-pub(super) struct CommandDataBlock([u8; 16]);
-impl CommandDataBlock {
-    pub(super) fn inquiry() -> Self {
-        let mut b = Self::default();
-        b.set_command(Command::Inquiry);
-        b.0[4] = 0x24;
-        b
-    }
-
-    pub(super) fn read_capacity() -> Self {
-        let mut b = Self::default();
-        b.set_command(Command::ReadCapacity);
-        b
-    }
-
-    pub(super) fn read10() -> Self {
-        let mut b = Self::default();
-        b.set_command(Command::Read10);
-        b.0[8] = 0x40;
-        b
-    }
-
-    pub(super) fn write10() -> Self {
-        let mut b = Self::default();
-        b.set_command(Command::Write10);
-        b.0[8] = 0x40;
-        b
-    }
-
-    fn set_command(&mut self, c: Command) {
-        self.0[0] = c.into();
-    }
-}
-
-#[repr(u8)]
-enum Command {
-    Inquiry = 0x12,
-    ReadCapacity = 0x25,
-    Read10 = 0x28,
-    Write10 = 0x2a,
-}
-impl From<Command> for u8 {
-    fn from(c: Command) -> Self {
-        c as u8
-    }
 }
 
 #[repr(C, packed)]

--- a/kernel/src/device/pci/xhci/port/class_driver/mass_storage/scsi/mod.rs
+++ b/kernel/src/device/pci/xhci/port/class_driver/mass_storage/scsi/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+pub(super) mod command_data_block;
 pub(super) mod response;
 
 use num_derive::FromPrimitive;


### PR DESCRIPTION
- chore: add the `command_data_block` module
- refactor: move the definitions of CDB to the proper module

bors r+
