### PR TITLE
refactor: xhci task

### DIFF
--- a/kernel/src/device/pci/mod.rs
+++ b/kernel/src/device/pci/mod.rs
@@ -34,6 +34,8 @@ impl Iterator for IterPciDevices {
                     return Some(space);
                 }
             }
+
+            self.device = 0;
         }
 
         None

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -24,9 +24,7 @@ pub(crate) async fn task() {
 
     let event_ring = init();
 
-    port::spawn_all_connected_port_tasks();
-
-    multitask::add(Task::new_poll(event::task(event_ring)));
+    spawn_tasks(event_ring);
 }
 
 fn init_statics() -> Result<(), XhcNotFound> {
@@ -59,6 +57,12 @@ fn init() -> event::Ring {
     xhc::ensure_no_error_occurs();
 
     event_ring
+}
+
+fn spawn_tasks(e: event::Ring) {
+    port::spawn_all_connected_port_tasks();
+
+    multitask::add(Task::new_poll(event::task(e)));
 }
 
 fn iter_xhc() -> impl Iterator<Item = PhysAddr> {

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -16,7 +16,7 @@ use structures::{
 };
 use x86_64::PhysAddr;
 
-pub async fn task() {
+pub(crate) async fn task() {
     if init_statics().is_err() {
         warn!("xHC not found.");
         return;

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -17,14 +17,14 @@ use structures::{
 use x86_64::PhysAddr;
 
 pub(crate) async fn task() {
-    if init_statics().is_err() {
-        warn!("xHC not found.");
-        return;
+    if xhc::exists() {
+        info!("XHCI");
+        init_statics().expect("xHC should exist.");
+
+        let event_ring = init();
+
+        spawn_tasks(event_ring);
     }
-
-    let event_ring = init();
-
-    spawn_tasks(event_ring);
 }
 
 fn init_statics() -> Result<(), XhcNotFound> {

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -27,9 +27,6 @@ pub(crate) async fn task() {
     port::spawn_all_connected_port_tasks();
 
     multitask::add(Task::new_poll(event::task(event_ring)));
-
-    info!("Issuing the NOOP trb.");
-    exchanger::command::noop().await;
 }
 
 fn init_statics() -> Result<(), XhcNotFound> {

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -33,7 +33,7 @@ pub(crate) async fn task() {
 }
 
 fn init_statics() -> Result<(), XhcNotFound> {
-    match iter_devices().next() {
+    match iter_xhc().next() {
         Some(a) => {
             registers::init(a);
             extended_capabilities::init(a);
@@ -64,7 +64,7 @@ fn init() -> event::Ring {
     event_ring
 }
 
-fn iter_devices() -> impl Iterator<Item = PhysAddr> {
+fn iter_xhc() -> impl Iterator<Item = PhysAddr> {
     super::iter_devices().filter_map(|device| {
         if device.is_xhci() {
             Some(device.base_address(bar::Index::new(0)))

--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -29,9 +29,6 @@ fn init_statics() {
     extended_capabilities::init(a);
 }
 
-#[derive(Debug)]
-struct XhcNotFound;
-
 fn init_and_spawn_tasks() {
     init_statics();
 

--- a/kernel/src/device/pci/xhci/xhc.rs
+++ b/kernel/src/device/pci/xhci/xhc.rs
@@ -3,6 +3,10 @@
 use super::structures::{extended_capabilities, registers};
 use xhci::extended_capabilities::ExtendedCapability;
 
+pub(super) fn exists() -> bool {
+    super::iter_xhc().next().is_some()
+}
+
 pub fn init() {
     get_ownership_from_bios();
     stop_and_reset();

--- a/kernel/src/device/pci/xhci/xhc.rs
+++ b/kernel/src/device/pci/xhci/xhc.rs
@@ -24,6 +24,7 @@ pub fn run() {
 pub fn ensure_no_error_occurs() {
     registers::handle(|r| {
         let s = r.operational.usbsts.read();
+
         assert!(!s.hc_halted(), "HC is halted.");
         assert!(
             !s.host_system_error(),


### PR DESCRIPTION
- refactor: limit the visibility of a function
- refactor: rename to `iter_xhc`
- refactor: No-op command is no longer issued
- refactor: define the `spawn_tasks` function
- fix: wrong iteration of the PCI devices
- refactor: define `xhc::exists` function
- refactor: define `init_and_spawn_tasks`
- refactor: remove the unused struct
- refactor: remove the unused functions
- refactor: add a blank line

bors r+
