### PR TITLE
refactor: PCI config space

### DIFF
--- a/kernel/src/device/pci/config/common.rs
+++ b/kernel/src/device/pci/config/common.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::{RegisterIndex, Registers};
-use core::convert::TryFrom;
+use core::convert::{TryFrom, TryInto};
 
 #[derive(Debug)]
 pub struct Common<'a> {
@@ -71,14 +71,20 @@ impl<'a> Class<'a> {
     }
 
     fn base(&self) -> u8 {
-        u8::try_from((self.registers.get(RegisterIndex::new(2)) >> 24) & 0xff).unwrap()
+        ((self.registers.get(RegisterIndex::new(2)) >> 24) & 0xff)
+            .try_into()
+            .unwrap()
     }
 
     fn sub(&self) -> u8 {
-        u8::try_from((self.registers.get(RegisterIndex::new(2)) >> 16) & 0xff).unwrap()
+        ((self.registers.get(RegisterIndex::new(2)) >> 16) & 0xff)
+            .try_into()
+            .unwrap()
     }
 
     fn interface(&self) -> u8 {
-        u8::try_from((self.registers.get(RegisterIndex::new(2)) >> 8) & 0xff).unwrap()
+        ((self.registers.get(RegisterIndex::new(2)) >> 8) & 0xff)
+            .try_into()
+            .unwrap()
     }
 }

--- a/kernel/src/device/pci/config/common.rs
+++ b/kernel/src/device/pci/config/common.rs
@@ -60,7 +60,6 @@ pub enum BridgeType {
 struct Class<'a> {
     registers: &'a Registers,
 }
-
 impl<'a> Class<'a> {
     fn new(registers: &'a Registers) -> Self {
         Self { registers }

--- a/kernel/src/device/pci/config/common.rs
+++ b/kernel/src/device/pci/config/common.rs
@@ -17,7 +17,7 @@ impl<'a> Common<'a> {
         self.class().is_xhci()
     }
 
-    pub fn bridge_type(&self) -> BridgeType {
+    pub(super) fn bridge_type(&self) -> BridgeType {
         self.header_type().bridge_type()
     }
 
@@ -50,7 +50,7 @@ impl HeaderType {
 }
 
 #[derive(Debug)]
-pub enum BridgeType {
+pub(super) enum BridgeType {
     NonBridge,
     PciToPci,
     PciToCardbus,

--- a/kernel/src/device/pci/config/common.rs
+++ b/kernel/src/device/pci/config/common.rs
@@ -4,16 +4,16 @@ use super::{RegisterIndex, Registers};
 use core::convert::{TryFrom, TryInto};
 
 #[derive(Debug)]
-pub struct Common<'a> {
+pub(super) struct Common<'a> {
     registers: &'a Registers,
 }
 
 impl<'a> Common<'a> {
-    pub fn new(registers: &'a Registers) -> Self {
+    pub(super) fn new(registers: &'a Registers) -> Self {
         Self { registers }
     }
 
-    pub fn is_xhci(&self) -> bool {
+    pub(super) fn is_xhci(&self) -> bool {
         self.class().is_xhci()
     }
 

--- a/kernel/src/device/pci/config/common.rs
+++ b/kernel/src/device/pci/config/common.rs
@@ -67,7 +67,11 @@ impl<'a> Class<'a> {
     }
 
     fn is_xhci(&self) -> bool {
-        self.base() == 0x0c && self.sub() == 0x03 && self.interface() == 0x30
+        self.as_tuple() == (0x0c, 0x03, 0x30)
+    }
+
+    fn as_tuple(&self) -> (u8, u8, u8) {
+        (self.base(), self.sub(), self.interface())
     }
 
     fn base(&self) -> u8 {

--- a/kernel/src/device/pci/config/common.rs
+++ b/kernel/src/device/pci/config/common.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use bit_field::BitField;
-
 use super::{RegisterIndex, Registers};
+use bit_field::BitField;
 use core::convert::{TryFrom, TryInto};
 
 #[derive(Debug)]
 pub(super) struct Common<'a> {
     registers: &'a Registers,
 }
-
 impl<'a> Common<'a> {
     pub(super) fn new(registers: &'a Registers) -> Self {
         Self { registers }

--- a/kernel/src/device/pci/config/common.rs
+++ b/kernel/src/device/pci/config/common.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use bit_field::BitField;
+
 use super::{RegisterIndex, Registers};
 use core::convert::{TryFrom, TryInto};
 
@@ -74,20 +76,18 @@ impl<'a> Class<'a> {
     }
 
     fn base(&self) -> u8 {
-        ((self.registers.get(RegisterIndex::new(2)) >> 24) & 0xff)
-            .try_into()
-            .unwrap()
+        self.raw().get_bits(24..=31).try_into().unwrap()
     }
 
     fn sub(&self) -> u8 {
-        ((self.registers.get(RegisterIndex::new(2)) >> 16) & 0xff)
-            .try_into()
-            .unwrap()
+        self.raw().get_bits(16..=23).try_into().unwrap()
     }
 
     fn interface(&self) -> u8 {
-        ((self.registers.get(RegisterIndex::new(2)) >> 8) & 0xff)
-            .try_into()
-            .unwrap()
+        self.raw().get_bits(8..=15).try_into().unwrap()
+    }
+
+    fn raw(&self) -> u32 {
+        self.registers.get(RegisterIndex::new(2))
     }
 }

--- a/kernel/src/device/pci/config/common.rs
+++ b/kernel/src/device/pci/config/common.rs
@@ -62,12 +62,12 @@ struct Class<'a> {
 }
 
 impl<'a> Class<'a> {
-    fn is_xhci(&self) -> bool {
-        self.base() == 0x0c && self.sub() == 0x03 && self.interface() == 0x30
-    }
-
     fn new(registers: &'a Registers) -> Self {
         Self { registers }
+    }
+
+    fn is_xhci(&self) -> bool {
+        self.base() == 0x0c && self.sub() == 0x03 && self.interface() == 0x30
     }
 
     fn base(&self) -> u8 {

--- a/kernel/src/device/pci/config/type_spec/mod.rs
+++ b/kernel/src/device/pci/config/type_spec/mod.rs
@@ -10,19 +10,19 @@ use super::{
 use x86_64::PhysAddr;
 
 #[derive(Debug)]
-pub enum TypeSpec<'a> {
+pub(super) enum TypeSpec<'a> {
     NonBridge(non_bridge::TypeSpec<'a>),
 }
 
 impl<'a> TypeSpec<'a> {
-    pub fn new(registers: &'a Registers, common: &Common) -> Self {
+    pub(super) fn new(registers: &'a Registers, common: &Common) -> Self {
         match common.bridge_type() {
             BridgeType::NonBridge => TypeSpec::NonBridge(non_bridge::TypeSpec::new(registers)),
             e => panic!("Not implemented: {:?}\ncommon:{:?}", e, common),
         }
     }
 
-    pub fn base_address(&self, index: bar::Index) -> PhysAddr {
+    pub(super) fn base_address(&self, index: bar::Index) -> PhysAddr {
         let TypeSpec::NonBridge(non_bridge) = self;
         non_bridge.base_addr(index)
     }


### PR DESCRIPTION
- refactor: use `try_into`
- refactor: move the definition of the `new` method to the first
- refactor: define `as_tuple`
- refactor: remove a blank line
- refactor: restrict visibility
- refactor: restrict visibility
- refactor: define the `raw` method
- refactor: remove blank lines

bors r+
