### PR TITLE
chore: mark `init` functions as unsafe

### DIFF
--- a/kernel/src/device/pci/xhci/mod.rs
+++ b/kernel/src/device/pci/xhci/mod.rs
@@ -25,8 +25,11 @@ pub(crate) async fn task() {
 fn init_statics() {
     let a = iter_xhc().next().expect("xHC does not exist.");
 
-    registers::init(a);
-    extended_capabilities::init(a);
+    // SAFETY: BAR 0 address is passed.
+    unsafe {
+        registers::init(a);
+        extended_capabilities::init(a);
+    }
 }
 
 fn init_and_spawn_tasks() {

--- a/kernel/src/device/pci/xhci/structures/registers.rs
+++ b/kernel/src/device/pci/xhci/structures/registers.rs
@@ -9,14 +9,13 @@ use xhci::Registers;
 
 static REGISTERS: OnceCell<Spinlock<Registers<Mappers>>> = OnceCell::uninit();
 
-pub(in crate::device::pci::xhci) fn init(mmio_base: PhysAddr) {
+pub(in crate::device::pci::xhci) unsafe fn init(mmio_base: PhysAddr) {
     REGISTERS
         .try_init_once(|| {
-            Spinlock::new(
-                // SAFETY: The address is the correct one and the Registers are accessed only through
-                // this static.
-                unsafe { Registers::new(mmio_base.as_u64().try_into().unwrap(), Mappers::user()) },
-            )
+            Spinlock::new(Registers::new(
+                mmio_base.as_u64().try_into().unwrap(),
+                Mappers::user(),
+            ))
         })
         .expect("Failed to initialize `REGISTERS`.")
 }


### PR DESCRIPTION
The safeties depend on an argument.

bors r+
