### PR TITLE
refactor: rename `process::Id` to `SlotId`

### DIFF
--- a/kernel/src/process/collections/process.rs
+++ b/kernel/src/process/collections/process.rs
@@ -5,7 +5,7 @@ use crate::{process, process::Process};
 use alloc::collections::BTreeMap;
 use spinning_top::{Spinlock, SpinlockGuard};
 
-static PROCESSES: Spinlock<BTreeMap<process::Id, Process>> = Spinlock::new(BTreeMap::new());
+static PROCESSES: Spinlock<BTreeMap<process::SlotId, Process>> = Spinlock::new(BTreeMap::new());
 
 pub(in crate::process) fn add(p: Process) {
     let id = p.id();
@@ -23,7 +23,7 @@ where
     handle_mut(id, f)
 }
 
-pub(in crate::process) fn handle_mut<T, U>(id: process::Id, f: T) -> U
+pub(in crate::process) fn handle_mut<T, U>(id: process::SlotId, f: T) -> U
 where
     T: FnOnce(&mut Process) -> U,
 {
@@ -42,7 +42,7 @@ where
     handle(id, f)
 }
 
-pub(in crate::process) fn handle<T, U>(id: process::Id, f: T) -> U
+pub(in crate::process) fn handle<T, U>(id: process::SlotId, f: T) -> U
 where
     T: FnOnce(&Process) -> U,
 {
@@ -53,7 +53,7 @@ where
     f(p)
 }
 
-fn lock_processes() -> SpinlockGuard<'static, BTreeMap<process::Id, Process>> {
+fn lock_processes() -> SpinlockGuard<'static, BTreeMap<process::SlotId, Process>> {
     PROCESSES
         .try_lock()
         .expect("Failed to acquire the lock of `PROCESSES`.")

--- a/kernel/src/process/collections/woken_pid.rs
+++ b/kernel/src/process/collections/woken_pid.rs
@@ -5,10 +5,10 @@ use alloc::collections::VecDeque;
 use conquer_once::spin::Lazy;
 use spinning_top::{Spinlock, SpinlockGuard};
 
-static WOKEN_PIDS: Lazy<Spinlock<VecDeque<process::Id>>> =
+static WOKEN_PIDS: Lazy<Spinlock<VecDeque<process::SlotId>>> =
     Lazy::new(|| Spinlock::new(VecDeque::new()));
 
-pub(in crate::process) fn add(id: process::Id) {
+pub(in crate::process) fn add(id: process::SlotId) {
     lock_queue().push_back(id)
 }
 
@@ -16,21 +16,21 @@ pub(in crate::process) fn change_active_pid() {
     lock_queue().rotate_left(1)
 }
 
-pub(super) fn active_pid() -> process::Id {
+pub(super) fn active_pid() -> process::SlotId {
     lock_queue()[0]
 }
 
-pub(in crate::process) fn pop() -> process::Id {
+pub(in crate::process) fn pop() -> process::SlotId {
     lock_queue()
         .pop_front()
         .expect("All processes are terminated.")
 }
 
-pub(in crate::process) fn push(id: process::Id) {
+pub(in crate::process) fn push(id: process::SlotId) {
     lock_queue().push_back(id);
 }
 
-fn lock_queue() -> SpinlockGuard<'static, VecDeque<process::Id>> {
+fn lock_queue() -> SpinlockGuard<'static, VecDeque<process::SlotId>> {
     WOKEN_PIDS
         .try_lock()
         .expect("Failed to acquire the lock of `WOKEN_PIDS`.")

--- a/kernel/src/process/ipc.rs
+++ b/kernel/src/process/ipc.rs
@@ -127,7 +127,7 @@ impl Receiver {
         Self::wake_sender(src_pid);
     }
 
-    fn src_pid() -> super::Id {
+    fn src_pid() -> super::SlotId {
         collections::process::handle_running_mut(|p| {
             p.pids_try_to_send_this_process
                 .pop_front()
@@ -136,14 +136,14 @@ impl Receiver {
         .into()
     }
 
-    fn copy_msg(&self, src_pid: super::Id) {
+    fn copy_msg(&self, src_pid: super::SlotId) {
         let src = collections::process::handle(src_pid, |p| p.msg_ptr);
         let src = src.expect("The message pointer of the sender is not set.");
 
         unsafe { copy_msg(src, self.msg_buf) }
     }
 
-    fn wake_sender(src_pid: super::Id) {
+    fn wake_sender(src_pid: super::SlotId) {
         collections::process::handle_mut(src_pid, |p| {
             p.flags -= super::Flags::SENDING;
             p.msg_ptr = None;

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -47,7 +47,7 @@ fn push_process_to_queue(p: Process) {
     add_process(p);
 }
 
-fn add_pid(id: Id) {
+fn add_pid(id: SlotId) {
     collections::woken_pid::add(id);
 }
 
@@ -70,7 +70,7 @@ fn set_temporary_stack_frame() {
 
 #[derive(Debug)]
 pub struct Process {
-    id: Id,
+    id: SlotId,
     f: fn(),
     tables: page_table::Collection,
     pml4_addr: PhysAddr,
@@ -100,7 +100,7 @@ impl Process {
         let pml4_addr = tables.pml4_addr();
 
         Process {
-            id: Id::new(),
+            id: SlotId::new(),
             f,
             tables,
             pml4_addr,
@@ -114,7 +114,7 @@ impl Process {
         }
     }
 
-    fn id(&self) -> Id {
+    fn id(&self) -> SlotId {
         self.id
     }
 
@@ -146,8 +146,8 @@ pub enum Privilege {
 }
 
 #[derive(Copy, Clone, PartialOrd, PartialEq, Ord, Eq, Debug)]
-struct Id(i32);
-impl Id {
+struct SlotId(i32);
+impl SlotId {
     fn new() -> Self {
         static ID: AtomicI32 = AtomicI32::new(0);
         Self(ID.fetch_add(1, Ordering::Relaxed))
@@ -157,7 +157,7 @@ impl Id {
         self.0
     }
 }
-impl From<i32> for Id {
+impl From<i32> for SlotId {
     fn from(id: i32) -> Self {
         Self(id)
     }


### PR DESCRIPTION
This ID will be used by the kernel, file server, and process manager to
sync the process information.

bors r+
