### PR TITLE
refactor: depend on cargo to build the kernel library and bootx64.efi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,12 @@
 SHELL			:= /bin/bash
 
-RUST_SRC_DIR	:= src
 BUILD_DIR		:= build
 EFI_DIR			:= bootx64
-EFI_SRC_DIR		:= $(EFI_DIR)/$(RUST_SRC_DIR)
-COMMON_SRC_DIR	:= common
 KERNEL_DIR		:= kernel
-KERNEL_SRC_DIR	:= $(KERNEL_DIR)/$(RUST_SRC_DIR)
-
-CARGO_JSON		:= x86_64-unknown-ramen.json
-RUST_SRC		:= $(shell find $(KERNEL_DIR) -name '*.rs')
-EFI_SRC			:= $(shell find $(EFI_DIR) -name '*.rs')
-CARGO_TOML		:= Cargo.toml
-CONFIG_TOML		:= $(KERNEL_DIR)/.cargo/config.toml
-
-COMMON_SRC		:= $(addprefix $(COMMON_SRC_DIR)/$(RUST_SRC_DIR)/, $(shell ls $(COMMON_SRC_DIR)/$(RUST_SRC_DIR)))
 
 LD_SRC			:= $(KERNEL_DIR)/kernel.ld
 
 EFI_FILE		:= $(BUILD_DIR)/bootx64.efi
-
 KERNEL_FILE		:= $(BUILD_DIR)/kernel.bin
 LIB_FILE		:= $(BUILD_DIR)/libramen_os.a
 IMG_FILE		:= $(BUILD_DIR)/ramen_os.img
@@ -32,11 +19,9 @@ OVMF_CODE		:= OVMF_CODE.fd
 OVMF_VARS		:= OVMF_VARS.fd
 
 RUSTCFLAGS		:= --release
-
 LDFLAGS			:= -nostdlib -T $(LD_SRC)
 
-.PHONY:all copy_to_usb test clean
-
+.PHONY:all copy_to_usb test clean $(LIB_FILE) $(EFI_FILE)
 .SUFFIXES:
 
 all:$(KERNEL_FILE) $(EFI_FILE)
@@ -72,7 +57,7 @@ $(IMG_FILE):$(KERNEL_FILE) $(HEAD_FILE) $(EFI_FILE)
 $(KERNEL_FILE):$(LIB_FILE) $(LD_SRC)|$(BUILD_DIR)
 	$(LD) $(LDFLAGS) -o $@ $(LIB_FILE)
 
-$(LIB_FILE): $(RUST_SRC) $(COMMON_SRC) $(COMMON_SRC_DIR)/$(CARGO_TOML) $(KERNEL_DIR)/$(CARGO_TOML) $(KERNEL_DIR)/$(CARGO_JSON) $(CONFIG_TOML)|$(BUILD_DIR)
+$(LIB_FILE):|$(BUILD_DIR)
 	# FIXME: Currently `cargo` tries to read `$(pwd)/.cargo/config.toml`, not
 	# `$(dirname argument_of_--manifest-path)/.cargo/config.toml`.
 	# See: https://github.com/rust-lang/cargo/issues/2930
@@ -82,7 +67,7 @@ $(LIB_FILE): $(RUST_SRC) $(COMMON_SRC) $(COMMON_SRC_DIR)/$(CARGO_TOML) $(KERNEL_
 	@echo "$@ not found"
 	exit 1
 
-$(EFI_FILE):$(EFI_SRC) $(COMMON_SRC) $(COMMON_SRC_DIR)/$(CARGO_TOML) $(EFI_DIR)/$(CARGO_TOML)|$(BUILD_DIR)
+$(EFI_FILE):|$(BUILD_DIR)
 	cd $(EFI_DIR) && $(RUSTC) build --out-dir=../$(BUILD_DIR) -Z unstable-options $(RUSTCFLAGS)
 
 $(BUILD_DIR):


### PR DESCRIPTION
It is difficult to trace changes of files of source codes because these
crates depend on other crates in the ramen directory, and these
dependencies are often forgotten to write in the Makefile. Cargo exits
immediately if no changes occurred in the source codes. This commit
almost does not affect the building time.