### PR TITLE
fix: do not use `bootx64.efi` as the image of USB storage

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -4,7 +4,7 @@ readonly general_flags=" \
     -drive if=pflash,format=raw,file=OVMF_CODE.fd,readonly=on \
     -drive if=pflash,format=raw,file=OVMF_VARS.fd,readonly=on \
     -drive format=raw,file=build/ramen_os.img \
-    -drive id=usb,file=build/bootx64.efi,if=none,format=raw \
+    -drive id=usb,file=build/storage.img,if=none,format=raw \
     -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
     -device qemu-xhci,id=xhci \
     -device usb-kbd \
@@ -30,6 +30,7 @@ test_flags=" \
 if [[ $1 == "-t" ]]
 then
     make test -j
+    dd if=/dev/zero of=build/storage.img count=10000
     qemu-system-x86_64 ${test_flags}
     status=$?
     readonly ok_status=33
@@ -42,5 +43,6 @@ then
     fi
 else
     make build/ramen_os.img -j
+    dd if=/dev/zero of=build/storage.img count=10000
     qemu-system-x86_64 ${run_flags}
 fi


### PR DESCRIPTION
bors r+
