### PR TITLE
refactor: physical pages allocator

### DIFF
--- a/kernel/src/mem/allocator/phys.rs
+++ b/kernel/src/mem/allocator/phys.rs
@@ -28,12 +28,7 @@ impl FrameManager {
 
         for i in 0..self.0.len() {
             if self.0[i].is_available_for_allocating(num_of_pages) {
-                self.split_node(i, num_of_pages);
-
-                let addr = self.0[i].start;
-                self.0[i].available = false;
-
-                return Some(addr);
+                return Some(self.alloc_from_descriptor_index(i, num_of_pages));
             }
         }
 
@@ -56,6 +51,13 @@ impl FrameManager {
         }
 
         self.merge_all_nodes();
+    }
+
+    fn alloc_from_descriptor_index(&mut self, i: usize, n: NumOfPages<Size4KiB>) -> PhysAddr {
+        self.split_node(i, n);
+
+        self.0[i].available = false;
+        self.0[i].start
     }
 
     fn init_for_descriptor(&mut self, descriptor: &boot::MemoryDescriptor) {

--- a/kernel/src/mem/allocator/phys.rs
+++ b/kernel/src/mem/allocator/phys.rs
@@ -27,7 +27,7 @@ impl FrameManager {
         let num_of_pages = NumOfPages::new(num_of_pages.as_usize().next_power_of_two());
 
         for i in 0..self.0.len() {
-            if self.0[i].num_of_pages >= num_of_pages && self.0[i].available {
+            if self.0[i].is_available_for_allocating(num_of_pages) {
                 self.split_node(i, num_of_pages);
 
                 let addr = self.0[i].start;
@@ -167,5 +167,9 @@ impl Frames {
             num_of_pages,
             available: true,
         }
+    }
+
+    fn is_available_for_allocating(&self, request_num_of_pages: NumOfPages<Size4KiB>) -> bool {
+        self.num_of_pages >= request_num_of_pages && self.available
     }
 }

--- a/kernel/src/mem/allocator/phys.rs
+++ b/kernel/src/mem/allocator/phys.rs
@@ -84,17 +84,21 @@ impl FrameManager {
         }
 
         while self.0[i].num_of_pages > num_of_pages {
-            let start = self.0[i].start;
-            let num_of_pages = self.0[i].num_of_pages;
-
-            let new_frames = Frames::new_for_available(
-                start + num_of_pages.as_bytes().as_usize() / 2,
-                num_of_pages / 2,
-            );
-
-            self.0[i].num_of_pages /= 2;
-            self.0.insert(i + 1, new_frames);
+            self.split_node_into_half(i);
         }
+    }
+
+    fn split_node_into_half(&mut self, i: usize) {
+        let start = self.0[i].start;
+        let num_of_pages = self.0[i].num_of_pages;
+
+        let new_frames = Frames::new_for_available(
+            start + num_of_pages.as_bytes().as_usize() / 2,
+            num_of_pages / 2,
+        );
+
+        self.0[i].num_of_pages /= 2;
+        self.0.insert(i + 1, new_frames);
     }
 
     fn free_memory_for_descriptor_index(&mut self, i: usize) {

--- a/kernel/src/mem/allocator/phys.rs
+++ b/kernel/src/mem/allocator/phys.rs
@@ -17,7 +17,7 @@ pub(in super::super) static FRAME_MANAGER: Lazy<Spinlock<FrameManager>> =
     Lazy::new(|| Spinlock::new(FrameManager(VecDeque::new())));
 
 pub(crate) fn init(mem_map: &[boot::MemoryDescriptor]) {
-    FRAME_MANAGER.lock().init_static(mem_map);
+    FRAME_MANAGER.lock().init(mem_map);
     paging::mark_pages_as_unused();
 }
 
@@ -49,7 +49,7 @@ impl FrameManager {
         }
     }
 
-    fn init_static(&mut self, mem_map: &[boot::MemoryDescriptor]) {
+    fn init(&mut self, mem_map: &[boot::MemoryDescriptor]) {
         for descriptor in mem_map {
             if Self::available(descriptor.ty) {
                 self.init_for_descriptor(descriptor);

--- a/kernel/src/mem/allocator/phys.rs
+++ b/kernel/src/mem/allocator/phys.rs
@@ -70,7 +70,7 @@ impl FrameManager {
                     descriptor.phys_start + u64::try_from(offset.as_bytes().as_usize()).unwrap(),
                 );
                 let pages = NumOfPages::new(2_usize.pow(i));
-                let frames = Frames::available(addr, pages);
+                let frames = Frames::new_for_available(addr, pages);
 
                 self.0.push_back(frames);
 
@@ -85,7 +85,7 @@ impl FrameManager {
                 let start = self.0[i].start;
                 let num_of_pages = self.0[i].num_of_pages;
 
-                let new_frames = Frames::available(
+                let new_frames = Frames::new_for_available(
                     start + num_of_pages.as_bytes().as_usize() / 2,
                     num_of_pages / 2,
                 );
@@ -161,7 +161,7 @@ struct Frames {
     available: bool,
 }
 impl Frames {
-    fn available(start: PhysAddr, num_of_pages: NumOfPages<Size4KiB>) -> Self {
+    fn new_for_available(start: PhysAddr, num_of_pages: NumOfPages<Size4KiB>) -> Self {
         Self {
             start,
             num_of_pages,

--- a/kernel/src/mem/allocator/phys.rs
+++ b/kernel/src/mem/allocator/phys.rs
@@ -43,8 +43,7 @@ impl FrameManager {
     pub(super) fn free(&mut self, addr: PhysAddr) {
         for i in 0..self.0.len() {
             if self.0[i].start == addr && !self.0[i].available {
-                self.0[i].available = true;
-                return self.merge_all_nodes();
+                return self.free_memory_for_descriptor_index(i);
             }
         }
     }
@@ -94,6 +93,11 @@ impl FrameManager {
                 self.0.insert(i + 1, new_frames);
             }
         }
+    }
+
+    fn free_memory_for_descriptor_index(&mut self, i: usize) {
+        self.0[i].available = true;
+        self.merge_all_nodes();
     }
 
     fn merge_all_nodes(&mut self) {

--- a/kernel/src/mem/allocator/phys.rs
+++ b/kernel/src/mem/allocator/phys.rs
@@ -105,8 +105,7 @@ impl FrameManager {
         // This will make it faster to search a small amount of memory.
         for i in (0..self.0.len()).rev() {
             if self.mergeable(i) {
-                self.merge_two_nodes(i);
-                return self.merge_all_nodes();
+                return self.merge_node(i);
             }
         }
     }
@@ -134,6 +133,11 @@ impl FrameManager {
 
     fn two_nodes_have_same_pages(node: &Frames, next: &Frames) -> bool {
         node.num_of_pages == next.num_of_pages
+    }
+
+    fn merge_node(&mut self, i: usize) {
+        self.merge_two_nodes(i);
+        self.merge_all_nodes();
     }
 
     fn merge_two_nodes(&mut self, i: usize) {

--- a/kernel/src/mem/allocator/phys.rs
+++ b/kernel/src/mem/allocator/phys.rs
@@ -70,7 +70,7 @@ impl FrameManager {
                     descriptor.phys_start + u64::try_from(offset.as_bytes().as_usize()).unwrap(),
                 );
                 let pages = NumOfPages::new(2_usize.pow(i));
-                let frames = Frames::new(addr, pages, true);
+                let frames = Frames::available(addr, pages);
 
                 self.0.push_back(frames);
 
@@ -85,10 +85,9 @@ impl FrameManager {
                 let start = self.0[i].start;
                 let num_of_pages = self.0[i].num_of_pages;
 
-                let new_frames = Frames::new(
+                let new_frames = Frames::available(
                     start + num_of_pages.as_bytes().as_usize() / 2,
                     num_of_pages / 2,
-                    true,
                 );
 
                 self.0[i].num_of_pages /= 2;
@@ -162,11 +161,11 @@ struct Frames {
     available: bool,
 }
 impl Frames {
-    fn new(start: PhysAddr, num_of_pages: NumOfPages<Size4KiB>, available: bool) -> Self {
+    fn available(start: PhysAddr, num_of_pages: NumOfPages<Size4KiB>) -> Self {
         Self {
             start,
             num_of_pages,
-            available,
+            available: true,
         }
     }
 }

--- a/kernel/src/mem/allocator/phys.rs
+++ b/kernel/src/mem/allocator/phys.rs
@@ -79,19 +79,21 @@ impl FrameManager {
     }
 
     fn split_node(&mut self, i: usize, num_of_pages: NumOfPages<Size4KiB>) {
-        if self.0[i].available {
-            while self.0[i].num_of_pages > num_of_pages {
-                let start = self.0[i].start;
-                let num_of_pages = self.0[i].num_of_pages;
+        if !self.0[i].available {
+            return;
+        }
 
-                let new_frames = Frames::new_for_available(
-                    start + num_of_pages.as_bytes().as_usize() / 2,
-                    num_of_pages / 2,
-                );
+        while self.0[i].num_of_pages > num_of_pages {
+            let start = self.0[i].start;
+            let num_of_pages = self.0[i].num_of_pages;
 
-                self.0[i].num_of_pages /= 2;
-                self.0.insert(i + 1, new_frames);
-            }
+            let new_frames = Frames::new_for_available(
+                start + num_of_pages.as_bytes().as_usize() / 2,
+                num_of_pages / 2,
+            );
+
+            self.0[i].num_of_pages /= 2;
+            self.0.insert(i + 1, new_frames);
         }
     }
 

--- a/kernel/src/mem/allocator/phys.rs
+++ b/kernel/src/mem/allocator/phys.rs
@@ -111,16 +111,16 @@ impl FrameManager {
     }
 
     fn mergeable(&self, i: usize) -> bool {
-        if i < self.0.len() - 1 {
-            let node = &self.0[i];
-            let next = &self.0[i + 1];
-
-            Self::two_nodes_available(node, next)
-                && Self::two_nodes_consecutive(node, next)
-                && Self::two_nodes_have_same_pages(node, next)
-        } else {
-            false
+        if i >= self.0.len() - 1 {
+            return false;
         }
+
+        let node = &self.0[i];
+        let next = &self.0[i + 1];
+
+        Self::two_nodes_available(node, next)
+            && Self::two_nodes_consecutive(node, next)
+            && Self::two_nodes_have_same_pages(node, next)
     }
 
     fn two_nodes_available(node: &Frames, next: &Frames) -> bool {


### PR DESCRIPTION
- refactor: remove a parameter whose type is boolean
- refactor: rename `init_static` to `init`
- refactor: add the `new` suffix
- refactor: define a method to ask whether an area is available
- refactor: move lines in an if statement to a new method
- refactor: move lines in a if statement to a new method
- refactor: return immediately if a condition is not met
- refactor: use the guard return
- refactor: define `split_node_into_half` method
- refactor: define the `alloc_from_descriptor_index` method

bors r+
