### PR TITLE
refactor: disable tests for the crate `bootx64`

### DIFF
--- a/bootx64/Cargo.toml
+++ b/bootx64/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "GPL-3.0-or-later"
 
 [[bin]]
+name = "bootx64"
 test = false
 bench = false
 

--- a/bootx64/Cargo.toml
+++ b/bootx64/Cargo.toml
@@ -10,6 +10,10 @@ name = "bootx64"
 test = false
 bench = false
 
+[lib]
+test = false
+bench = false
+
 [dependencies]
 log = "0.4.14"
 uefi = { version = "0.8.0", features = ["logger"] }

--- a/bootx64/Cargo.toml
+++ b/bootx64/Cargo.toml
@@ -5,7 +5,9 @@ authors = ["toku-sa-n <tokusan441@gmail.com>"]
 edition = "2018"
 license = "GPL-3.0-or-later"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+test = false
+bench = false
 
 [dependencies]
 log = "0.4.14"

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -39,8 +39,7 @@ then
     make test -j
     create_storage_image
 
-    # The target `x86_64-unknown-uefi` does not have `std`.
-    find . -name Cargo.toml -printf '%h\n'|grep -v bootx64|xargs -P 2 -I {} sh -c "cd {} && cargo test || exit 255"
+    find . -name Cargo.toml -printf '%h\n'|xargs -P 2 -I {} sh -c "cd {} && cargo test || exit 255"
 
     # QEMU exist with the exit code nonzero value even on success.
     set +e


### PR DESCRIPTION
- chore: disable tests for the crate `bootx64`
- refactor: `bootx64` crate is no longer excluded from testing

bors r+
