### PR TITLE
chore: remove the buddy-like altorithm from the frame manager

### DIFF
--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -195,7 +195,14 @@ impl Frames {
 }
 impl fmt::Debug for Frames {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Frames({:?} .. {:?})", self.start, self.end())
+        let suffix = if self.available { "Available" } else { "Used" };
+        write!(
+            f,
+            "Frames::<{}>({:?} .. {:?})",
+            suffix,
+            self.start,
+            self.end()
+        )
     }
 }
 

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -196,13 +196,13 @@ mod tests {
     use x86_64::PhysAddr;
 
     macro_rules! frames {
-        (Available $start:expr => $end:expr) => {
+        (A $start:expr => $end:expr) => {
             Frames::new_for_available(
                 PhysAddr::new($start),
                 os_units::Bytes::new($end - $start).as_num_of_pages(),
             )
         };
-        (Used $start:expr => $end:expr) => {
+        (U $start:expr => $end:expr) => {
             Frames::new_for_used(
                 PhysAddr::new($start),
                 os_units::Bytes::new($end - $start).as_num_of_pages(),
@@ -228,10 +228,10 @@ mod tests {
         assert_eq!(
             f,
             FrameManager(vec![
-                frames!(Available 0 => 0x1000),
-                frames!(Used 0x2000 => 0x5000),
-                frames!(Available 0x5000 => 0xc000),
-                frames!(Used 0xc000 => 0x10000),
+                frames!(A 0 => 0x1000),
+                frames!(U 0x2000 => 0x5000),
+                frames!(A 0x5000 => 0xc000),
+                frames!(U 0xc000 => 0x10000),
             ])
         );
     }
@@ -244,26 +244,23 @@ mod tests {
 
         assert_eq!(
             f,
-            FrameManager(vec![
-                frames!(Available 0 => 0x1000),
-                frames!(Available 0x2000 => 0x10000),
-            ])
+            FrameManager(vec![frames!(A 0 => 0x1000), frames!(A 0x2000 => 0x10000),])
         );
     }
 
     #[test]
     fn mergable_two_frmaes() {
-        let f1 = frames!(Available 0x2000 => 0xc000);
-        let f2 = frames!(Available 0xc000 => 0x10000);
+        let f1 = frames!(A 0x2000 => 0xc000);
+        let f2 = frames!(A 0xc000 => 0x10000);
 
         assert!(f1.is_mergeable(&f2));
     }
 
     fn frame_manager_for_testing() -> FrameManager {
         let f = vec![
-            frames!(Available 0 => 0x1000),
-            frames!(Available 0x2000 => 0xc000),
-            frames!(Used 0xc000 => 0x10000),
+            frames!(A 0 => 0x1000),
+            frames!(A 0x2000 => 0xc000),
+            frames!(U 0xc000 => 0x10000),
         ];
 
         FrameManager(f)

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -313,6 +313,19 @@ mod tests {
     }
 
     #[test]
+    fn free_and_merge_with_before_and_after() {
+        let mut f = manager!(
+            A 0 => 0x3000,
+            U 0x3000 => 0x5000,
+            A 0x5000 => 0x10000,
+        );
+
+        f.free(PhysAddr::new(0x3000));
+
+        assert_eq!(f, manager!(A 0 => 0x10000))
+    }
+
+    #[test]
     fn mergable_two_frmaes() {
         let f1 = frames!(A 0x2000 => 0xc000);
         let f2 = frames!(A 0xc000 => 0x10000);

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -269,6 +269,14 @@ mod tests {
     }
 
     #[test]
+    fn free_single_frames() {
+        let mut f = manager!(U 0 => 0x3000);
+        f.free(PhysAddr::zero());
+
+        assert_eq!(f, manager!(A 0 => 0x3000));
+    }
+
+    #[test]
     fn free_and_merge_with_before() {
         let mut f = manager!(
             A 0 => 0x1000,

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #![cfg_attr(not(test), no_std)]
-#![feature(int_bits_const)]
 
 extern crate alloc;
 

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -8,7 +8,10 @@ extern crate alloc;
 use alloc::vec::Vec;
 use bit_field::BitField;
 use boot::MemoryType;
-use core::convert::{TryFrom, TryInto};
+use core::{
+    convert::{TryFrom, TryInto},
+    fmt,
+};
 use os_units::NumOfPages;
 use uefi::table::boot;
 use x86_64::{
@@ -155,7 +158,7 @@ impl FrameDeallocator<Size4KiB> for FrameManager {
     }
 }
 
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq)]
 struct Frames {
     start: PhysAddr,
     num_of_pages: NumOfPages<Size4KiB>,
@@ -188,6 +191,11 @@ impl Frames {
 
     fn is_same_size(&self, other: &Self) -> bool {
         self.num_of_pages == other.num_of_pages
+    }
+}
+impl fmt::Debug for Frames {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Frames({:?} .. {:?})", self.start, self.end())
     }
 }
 

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -224,10 +224,26 @@ mod tests {
         );
     }
 
+    #[test]
+    fn free() {
+        let mut f = frame_manager_for_testing();
+
+        f.free(PhysAddr::new(0xc000));
+
+        assert_eq!(
+            f,
+            FrameManager(vec![
+                Frames::new_for_available(PhysAddr::zero(), NumOfPages::new(1)),
+                Frames::new_for_available(PhysAddr::new(0x2000), NumOfPages::new(14))
+            ])
+        );
+    }
+
     fn frame_manager_for_testing() -> FrameManager {
         let f = vec![
             Frames::new_for_available(PhysAddr::zero(), NumOfPages::new(1)),
             Frames::new_for_available(PhysAddr::new(0x2000), NumOfPages::new(10)),
+            Frames::new_for_used(PhysAddr::new(0xc000), NumOfPages::new(4)),
         ];
 
         FrameManager(f)

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -205,10 +205,10 @@ mod tests {
     }
 
     fn frame_manager_for_testing() -> FrameManager {
-        let f = vec![Frames::new_for_available(
-            PhysAddr::zero(),
-            NumOfPages::new(1),
-        )];
+        let f = vec![
+            Frames::new_for_available(PhysAddr::zero(), NumOfPages::new(1)),
+            Frames::new_for_available(PhysAddr::new(0x2000), NumOfPages::new(10)),
+        ];
 
         FrameManager(f)
     }

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -296,6 +296,23 @@ mod tests {
     }
 
     #[test]
+    fn free_and_merge_with_after() {
+        let mut f = manager!(
+            U 0 => 0x3000,
+            A 0x3000 => 0x5000,
+        );
+
+        f.free(PhysAddr::zero());
+
+        assert_eq!(
+            f,
+            manager!(
+                A 0 => 0x5000,
+            )
+        )
+    }
+
+    #[test]
     fn mergable_two_frmaes() {
         let f1 = frames!(A 0x2000 => 0xc000);
         let f2 = frames!(A 0xc000 => 0x10000);

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -226,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn free() {
+    fn free_and_merge_with_before() {
         let mut f = frame_manager_for_testing();
 
         f.free(PhysAddr::new(0xc000));
@@ -238,6 +238,14 @@ mod tests {
                 Frames::new_for_available(PhysAddr::new(0x2000), NumOfPages::new(14))
             ])
         );
+    }
+
+    #[test]
+    fn mergable_two_frmaes() {
+        let f1 = Frames::new_for_available(PhysAddr::new(0x2000), NumOfPages::new(10));
+        let f2 = Frames::new_for_available(PhysAddr::new(0xc000), NumOfPages::new(4));
+
+        assert!(f1.is_mergeable(&f2));
     }
 
     fn frame_manager_for_testing() -> FrameManager {

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -51,7 +51,9 @@ impl FrameManager {
     }
 
     fn alloc_from_frames_at(&mut self, i: usize, n: NumOfPages<Size4KiB>) -> PhysAddr {
-        self.split_frames(i, n);
+        if self.0[i].is_splittable(n) {
+            self.split_frames(i, n);
+        }
 
         self.0[i].available = false;
         self.0[i].start
@@ -152,6 +154,10 @@ impl Frames {
             num_of_pages,
             available: false,
         }
+    }
+
+    fn is_splittable(&self, requested: NumOfPages<Size4KiB>) -> bool {
+        self.num_of_pages > requested
     }
 
     fn is_available_for_allocating(&self, request_num_of_pages: NumOfPages<Size4KiB>) -> bool {

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -200,7 +200,7 @@ mod tests {
     fn fail_to_allocate() {
         let mut f = frame_manager_for_testing();
 
-        let a = f.alloc(NumOfPages::new(5));
+        let a = f.alloc(NumOfPages::new(200));
         assert!(a.is_none());
     }
 

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -210,6 +210,15 @@ mod tests {
         };
     }
 
+    macro_rules! manager {
+        ($($is_available:ident $start:expr => $end:expr),*$(,)*) => {
+            FrameManager(vec![
+                $(frames!($is_available $start => $end)),*
+            ]
+            )
+        };
+    }
+
     #[test]
     fn fail_to_allocate() {
         let mut f = frame_manager_for_testing();
@@ -227,13 +236,13 @@ mod tests {
         assert_eq!(a, Some(PhysAddr::new(0x2000)));
         assert_eq!(
             f,
-            FrameManager(vec![
-                frames!(A 0 => 0x1000),
-                frames!(U 0x2000 => 0x5000),
-                frames!(A 0x5000 => 0xc000),
-                frames!(U 0xc000 => 0x10000),
-            ])
-        );
+            manager!(
+            A 0 => 0x1000,
+            U 0x2000 => 0x5000,
+            A 0x5000 => 0xc000,
+            U 0xc000 => 0x10000,
+            )
+        )
     }
 
     #[test]
@@ -244,8 +253,11 @@ mod tests {
 
         assert_eq!(
             f,
-            FrameManager(vec![frames!(A 0 => 0x1000), frames!(A 0x2000 => 0x10000),])
-        );
+            manager! (
+                A 0 => 0x1000,
+                A 0x2000 => 0x10000
+            )
+        )
     }
 
     #[test]
@@ -257,12 +269,10 @@ mod tests {
     }
 
     fn frame_manager_for_testing() -> FrameManager {
-        let f = vec![
-            frames!(A 0 => 0x1000),
-            frames!(A 0x2000 => 0xc000),
-            frames!(U 0xc000 => 0x10000),
-        ];
-
-        FrameManager(f)
+        manager!(
+            A 0 => 0x1000,
+            A 0x2000 => 0xc000,
+            U 0xc000 => 0x10000,
+        )
     }
 }

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -189,3 +189,22 @@ impl Frames {
         self.num_of_pages == other.num_of_pages
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{FrameManager, Frames};
+    use os_units::NumOfPages;
+    use x86_64::PhysAddr;
+
+    #[test]
+    fn fail_to_allocate() {
+        let f = vec![Frames::new_for_available(
+            PhysAddr::new(0),
+            NumOfPages::new(1),
+        )];
+        let mut f = FrameManager(f);
+
+        let a = f.alloc(NumOfPages::new(5));
+        assert!(a.is_none());
+    }
+}

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -198,13 +198,18 @@ mod tests {
 
     #[test]
     fn fail_to_allocate() {
-        let f = vec![Frames::new_for_available(
-            PhysAddr::new(0),
-            NumOfPages::new(1),
-        )];
-        let mut f = FrameManager(f);
+        let mut f = frame_manager_for_testing();
 
         let a = f.alloc(NumOfPages::new(5));
         assert!(a.is_none());
+    }
+
+    fn frame_manager_for_testing() -> FrameManager {
+        let f = vec![Frames::new_for_available(
+            PhysAddr::zero(),
+            NumOfPages::new(1),
+        )];
+
+        FrameManager(f)
     }
 }

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -16,6 +16,7 @@ use x86_64::{
 
 extern crate alloc;
 
+#[derive(PartialEq, Eq, Debug)]
 pub struct FrameManager(Vec<Frames>);
 impl FrameManager {
     #[must_use]
@@ -154,7 +155,7 @@ impl FrameDeallocator<Size4KiB> for FrameManager {
     }
 }
 
-#[derive(Debug)]
+#[derive(PartialEq, Eq, Debug)]
 struct Frames {
     start: PhysAddr,
     num_of_pages: NumOfPages<Size4KiB>,
@@ -202,6 +203,22 @@ mod tests {
 
         let a = f.alloc(NumOfPages::new(200));
         assert!(a.is_none());
+    }
+
+    #[test]
+    fn allocate_not_power_of_two() {
+        let mut f = frame_manager_for_testing();
+
+        let a = f.alloc(NumOfPages::new(3));
+
+        assert_eq!(a, Some(PhysAddr::new(0x2000)));
+        assert_eq!(
+            f,
+            FrameManager(vec![
+                Frames::new_for_available(PhysAddr::zero(), NumOfPages::new(1)),
+                Frames::new_for_available(PhysAddr::new(0x5000), NumOfPages::new(7))
+            ])
+        );
     }
 
     fn frame_manager_for_testing() -> FrameManager {

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -70,7 +70,7 @@ impl FrameManager {
         assert!(self.0[i].available, "Frames are not available.");
         assert!(
             self.0[i].num_of_pages > num_of_pages,
-            "Cannot split frames."
+            "Insufficient number of frames."
         );
 
         unsafe { self.split_node_unchecked(i, num_of_pages) }
@@ -78,9 +78,10 @@ impl FrameManager {
 
     unsafe fn split_node_unchecked(&mut self, i: usize, requested: NumOfPages<Size4KiB>) {
         let new_frames_start = self.0[i].start + requested.as_bytes().as_usize();
-        let new_frames = Frames::new_for_available(new_frames_start, requested);
+        let new_frames_num = self.0[i].num_of_pages - requested;
+        let new_frames = Frames::new_for_available(new_frames_start, new_frames_num);
 
-        self.0[i].num_of_pages -= requested;
+        self.0[i].num_of_pages = requested;
         self.0.insert(i + 1, new_frames);
     }
 

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -219,7 +219,13 @@ mod tests {
 
     #[test]
     fn fail_to_allocate() {
-        let mut f = frame_manager_for_testing();
+        let mut f = manager!(
+            A 0 => 0x1000,
+            A 0x2000 => 0xc000,
+            U 0xc000 => 0x10000,
+            U 0x10000 => 0x13000,
+            A 0x13000 => 0x15000,
+        );
 
         let a = f.alloc(NumOfPages::new(200));
         assert!(a.is_none());
@@ -227,7 +233,11 @@ mod tests {
 
     #[test]
     fn allocate_not_power_of_two() {
-        let mut f = frame_manager_for_testing();
+        let mut f = manager!(
+            A 0 => 0x1000,
+            A 0x2000 => 0xc000,
+            U 0xc000 => 0x10000,
+        );
 
         let a = f.alloc(NumOfPages::new(3));
 
@@ -245,7 +255,11 @@ mod tests {
 
     #[test]
     fn free_and_merge_with_before() {
-        let mut f = frame_manager_for_testing();
+        let mut f = manager!(
+            A 0 => 0x1000,
+            A 0x2000 => 0xc000,
+            U 0xc000 => 0x10000,
+        );
 
         f.free(PhysAddr::new(0xc000));
 
@@ -264,13 +278,5 @@ mod tests {
         let f2 = frames!(A 0xc000 => 0x10000);
 
         assert!(f1.is_mergeable(&f2));
-    }
-
-    fn frame_manager_for_testing() -> FrameManager {
-        manager!(
-            A 0 => 0x1000,
-            A 0x2000 => 0xc000,
-            U 0xc000 => 0x10000,
-        )
     }
 }

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -219,7 +219,8 @@ mod tests {
             FrameManager(vec![
                 Frames::new_for_available(PhysAddr::zero(), NumOfPages::new(1)),
                 Frames::new_for_used(PhysAddr::new(0x2000), NumOfPages::new(3)),
-                Frames::new_for_available(PhysAddr::new(0x5000), NumOfPages::new(7))
+                Frames::new_for_available(PhysAddr::new(0x5000), NumOfPages::new(7)),
+                Frames::new_for_used(PhysAddr::new(0xc000), NumOfPages::new(4)),
             ])
         );
     }

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -254,6 +254,15 @@ mod tests {
     }
 
     #[test]
+    fn allocate_full_frames() {
+        let mut f = manager!(A 0 => 0x3000);
+        let a = f.alloc(NumOfPages::new(3));
+
+        assert_eq!(a, Some(PhysAddr::zero()));
+        assert_eq!(f, manager!(U 0 => 0x3000));
+    }
+
+    #[test]
     fn free_and_merge_with_before() {
         let mut f = manager!(
             A 0 => 0x1000,

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -165,7 +165,7 @@ impl Frames {
     }
 
     fn is_mergeable(&self, other: &Self) -> bool {
-        self.available && other.available && self.is_consecutive(other) && self.is_same_size(other)
+        self.available && other.available && self.is_consecutive(other)
     }
 
     fn is_consecutive(&self, other: &Self) -> bool {
@@ -174,10 +174,6 @@ impl Frames {
 
     fn end(&self) -> PhysAddr {
         self.start + self.num_of_pages.as_bytes().as_usize()
-    }
-
-    fn is_same_size(&self, other: &Self) -> bool {
-        self.num_of_pages == other.num_of_pages
     }
 }
 impl fmt::Debug for Frames {

--- a/frame_manager/src/lib.rs
+++ b/frame_manager/src/lib.rs
@@ -97,7 +97,7 @@ impl FrameManager {
             self.merge_to_next_frames(i);
         }
 
-        if self.mergeable_to_next_frames(i - 1) {
+        if i > 0 && self.mergeable_to_next_frames(i - 1) {
             self.merge_to_next_frames(i - 1);
         }
     }


### PR DESCRIPTION
The previous implementation used the buddy-like algorithm. However, it was not complete. This PR removes the buddy-like algorithm and instead use the flat list algorithm. It is simple and easy to test.
