### PR TITLE
refactor: use `into` instead of `from`

### DIFF
--- a/kernel/src/device/pci/xhci/structures/ring/event/segment_table.rs
+++ b/kernel/src/device/pci/xhci/structures/ring/event/segment_table.rs
@@ -56,7 +56,7 @@ impl Entry {
     // Although the size of segment_size is u64, bits 16:63 are reserved.
     pub fn set(&mut self, addr: PhysAddr, size: u16) {
         self.base_address = addr.as_u64();
-        self.segment_size = u64::from(size);
+        self.segment_size = size.into();
     }
 
     fn null() -> Self {


### PR DESCRIPTION
bors r+
