### PR TITLE
ci: we no longer use Bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,0 @@
-status = ["fmt", "clippy", "udeps", "test", "test_per_crate"]
-delete_merged_branches = true


### PR DESCRIPTION
Bors can do a squash merge, but it will mark a PR as closed, not merged.