### PR TITLE
chore: create the port server binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ $(PORT_SERVER):$(PORT_SERVER_LIB)|$(BUILD_DIR)
 	$(LD) $(LDFLAGS) -o $@ -e main $^
 
 $(PORT_SERVER_LIB):$(PORT_SERVER_SRC) $(PORT_SERVER_DEPENDENCIES_SRC)|$(BUILD_DIR)
-	cd $(PORT_SERVER_DIR) && $(RUSTC) build --out-dir ../$(BUILD_DIR) -Z unstable-options $(RUSTFLAGS)
+	cd $(PORT_SERVER_DIR) && $(RUSTC) build --out-dir ../$(BUILD_DIR) -Z unstable-options $(RUSTCFLAGS)
 
 $(EFI_FILE):$(EFI_SRC)|$(BUILD_DIR)
 	cd $(EFI_DIR) && $(RUSTC) build --out-dir=../$(BUILD_DIR) -Z unstable-options $(RUSTCFLAGS)

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -47,7 +47,6 @@ accessor = "0.3.0"
 message = { path = "../message" }
 bitflags = "1.2.1"
 byteorder = { version = "1.4.3", default-features = false }
-port_server = { path = "../port_server" }
 frame_manager = { path = "../frame_manager" }
 cstr_core = "0.2.3"
 fs_server = { path = "../fs_server" }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -84,7 +84,7 @@ fn init(boot_info: &mut kernelboot::Info) {
 }
 
 fn add_processes() {
-    process::add(port_server::main, Privilege::Kernel, "ps");
+    process::binary("build/port_server.bin", Privilege::Kernel);
     process::binary("build/pm.bin", Privilege::User);
     process::add(fs_server::main, Privilege::User, "fs");
     process::add(run_tasks, Privilege::User, "tasks");

--- a/port_server/.cargo/config.toml
+++ b/port_server/.cargo/config.toml
@@ -1,0 +1,6 @@
+[unstable]
+build-std = ["core", "compiler_builtins", "alloc"]
+build-std-features = ["compiler-builtins-mem"]
+
+[build]
+target = "x86_64-unknown-ramen.json"

--- a/port_server/Cargo.toml
+++ b/port_server/Cargo.toml
@@ -4,12 +4,17 @@ version = "0.1.0"
 authors = ["toku-sa-n <tokusan441@gmail.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = "port_server"
+crate-type = ["staticlib"]
+test = false
+bench = false
 
 [dependencies]
 log = "0.4.14"
 message = { path = "../message" }
 num-derive = "0.3.3"
 num-traits = { version = "0.2.14", default-features = false }
+ralib = { path = "../ralib" }
 syscalls = { path = "../syscalls" }
 x86_64 = "0.14.0"

--- a/port_server/src/lib.rs
+++ b/port_server/src/lib.rs
@@ -12,8 +12,14 @@ use num_traits::FromPrimitive;
 
 const PID: i32 = 0;
 
+#[no_mangle]
 pub fn main() {
+    init();
     main_loop();
+}
+
+fn init() {
+    ralib::init();
 }
 
 fn main_loop() {

--- a/port_server/x86_64-unknown-ramen.json
+++ b/port_server/x86_64-unknown-ramen.json
@@ -1,0 +1,22 @@
+{
+    "arch": "x86_64",
+    "":"See http://llvm.org/docs/LangRef.html#data-layout to know what data-layout represents.",
+    "data-layout": "e-m:e-i64:64-n8:16:32:64-S128",
+    "llvm-target": "x86_64-unknown-none",
+    "executables": true,
+    "features": "-sse,+soft-float",
+    "target-endian": "little",
+    "target-pointer-width": "64",
+    "target-c-int-width": "32",
+    "os": "none",
+    "code-model": "kernel",
+    "relocation-model": "static",
+    "archive-format": "gnu",
+    "target-env": "gnu",
+    "no-compiler-rt": false,
+    "panic-strategy": "abort",
+    "linker-flavor": "ld",
+    "linker-is-gnu": true,
+    "disable-redzone": true,
+    "eliminate-frame-pointer": false
+}


### PR DESCRIPTION
Currently, the process manager panics because it cannot get a lock of `HEAP`. This must be resolved.
