### PR TITLE
Revert "fix(ralib): forgot to add `cfg`"

### DIFF
--- a/ralib/src/mem/mod.rs
+++ b/ralib/src/mem/mod.rs
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 pub mod accessor;
-
-#[cfg(feature = "heap")]
 pub(crate) mod heap;


### PR DESCRIPTION
Reverts toku-sa-n/ramen#937

It turned out that adding the `heap` feature is useless. `_print` still uses the `String` type. 