### PR TITLE
Revert "chore(ralib): remove the `heap` feature"

### DIFF
--- a/ralib/Cargo.toml
+++ b/ralib/Cargo.toml
@@ -9,6 +9,10 @@ name = "ralib"
 test = false
 bench = false
 
+[features]
+default = ["heap"]
+heap = []
+
 [dependencies]
 conquer-once = { version = "0.3.2", default-features = false }
 linked_list_allocator = "0.9.0"

--- a/ralib/src/lib.rs
+++ b/ralib/src/lib.rs
@@ -2,16 +2,23 @@
 
 #![no_std]
 #![allow(clippy::too_many_arguments)] // A workaround for the clippy's wrong warning.
-#![feature(alloc_error_handler)]
+#![cfg_attr(feature = "heap", feature(alloc_error_handler))]
 
 pub mod io;
 pub mod mem;
 
+#[cfg(feature = "heap")]
 extern crate alloc;
 
+#[cfg(feature = "heap")]
 pub fn init() {
     io::init();
     mem::heap::init();
+}
+
+#[cfg(not(feature = "heap"))]
+pub fn init() {
+    io::init();
 }
 
 #[panic_handler]


### PR DESCRIPTION
Reverts toku-sa-n/ramen#939

Memory managers can use their own heap systems rather than the ones provided by `ralib`.