### PR TITLE
refactor(kernel): inline external assemblies

### DIFF
--- a/kernel/src/asm.s
+++ b/kernel/src/asm.s
@@ -1,26 +1,18 @@
-    .text
-    .code64
-    .intel_syntax noprefix
+.text
+.code64
+.intel_syntax noprefix
 
-    .set INTERRUPT_STACK, 0xffffffffc0000000 - (0x1000 * 16 / 2)
+.set INTERRUPT_STACK, 0xffffffffc0000000 - (0x1000 * 16 / 2)
 
-    .global cause_timer_interrupt_asm
-cause_timer_interrupt_asm:
-    int 0x20
+.global syscall_prepare_arguments
+.extern select_proper_syscall
 
-    .global syscall_prepare_arguments
-    .extern select_proper_syscall
 syscall_prepare_arguments:
-    mov rcx, rdx
-    mov rdx, rsi
-    mov rsi, rdi
-    mov rdi, rax
+	mov rcx, rdx
+	mov rdx, rsi
+	mov rsi, rdi
+	mov rdi, rax
 
-    call select_proper_syscall
+	call select_proper_syscall
 
-    ret
-
-    .global prepare_exit_syscall
-prepare_exit_syscall:
-    mov rsp, INTERRUPT_STACK
-    call exit_process
+	ret

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #![no_std]
-#![feature(alloc_error_handler, const_btree_new)]
+#![feature(alloc_error_handler, asm, const_btree_new)]
 #![deny(clippy::pedantic, clippy::all)]
 
 extern crate alloc;
@@ -24,6 +24,7 @@ use interrupt::{apic, idt, timer};
 use log::info;
 use process::Privilege;
 use terminal::vram;
+use x86_64::software_interrupt;
 
 #[no_mangle]
 pub extern "win64" fn os_main(mut boot_info: kernelboot::Info) -> ! {
@@ -76,11 +77,11 @@ fn add_processes() {
 }
 
 fn cause_timer_interrupt() -> ! {
-    extern "C" {
-        fn cause_timer_interrupt_asm() -> !;
+    unsafe {
+        software_interrupt!(0x20);
     }
 
-    unsafe { cause_timer_interrupt_asm() }
+    unreachable!();
 }
 
 fn do_nothing() {

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#[no_mangle]
-extern "C" fn exit_process() -> ! {
+use x86_64::software_interrupt;
+
+pub(crate) fn exit_process() -> ! {
     super::set_temporary_stack_frame();
     // TODO: Call this. Currently this calling will cause a panic because the `KBox` is not mapped
     // to this process.
@@ -12,9 +13,9 @@ extern "C" fn exit_process() -> ! {
 }
 
 fn cause_timer_interrupt() -> ! {
-    extern "C" {
-        fn cause_timer_interrupt_asm() -> !;
+    unsafe {
+        software_interrupt!(0x20);
     }
 
-    unsafe { cause_timer_interrupt_asm() }
+    unreachable!();
 }

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -12,6 +12,7 @@ use crate::{mem::allocator::kpbox::KpBox, tss::TSS};
 use alloc::collections::VecDeque;
 use common::constant::INTERRUPT_STACK;
 use core::convert::TryInto;
+pub(crate) use exit::exit_process;
 pub(crate) use slot_id::SlotId;
 use stack_frame::StackFrame;
 pub(crate) use switch::switch;


### PR DESCRIPTION
Using external assembly makes it difficult to debug code.
