### PR TITLE
removal of redundant woken_pid function

### DIFF
--- a/kernel/src/process/collections/woken_pid.rs
+++ b/kernel/src/process/collections/woken_pid.rs
@@ -8,10 +8,6 @@ use spinning_top::{Spinlock, SpinlockGuard};
 static WOKEN_PIDS: Lazy<Spinlock<VecDeque<process::SlotId>>> =
     Lazy::new(|| Spinlock::new(VecDeque::new()));
 
-pub(in crate::process) fn add(id: process::SlotId) {
-    lock_queue().push_back(id);
-}
-
 pub(in crate::process) fn change_active_pid() {
     lock_queue().rotate_left(1);
 }

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -48,7 +48,7 @@ fn push_process_to_queue(p: Process) {
 }
 
 fn add_pid(id: SlotId) {
-    collections::woken_pid::add(id);
+    collections::woken_pid::push(id);
 }
 
 fn add_process(p: Process) {


### PR DESCRIPTION
I noticed that in the woken_pid.rs the add and push functions have the same functionality so I removed one to clear up the redundancy