### PR TITLE
chore: create the `raheap` crate

### DIFF
--- a/libs/raheap/Cargo.toml
+++ b/libs/raheap/Cargo.toml
@@ -3,6 +3,11 @@ name = "raheap"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+name = "raheap"
+test = false
+bench = false
+
 [dependencies]
 conquer-once = { version = "0.3.2", default-features = false }
 linked_list_allocator = "0.9.0"

--- a/libs/raheap/Cargo.toml
+++ b/libs/raheap/Cargo.toml
@@ -1,23 +1,11 @@
 [package]
-name = "ralib"
+name = "raheap"
 version = "0.1.0"
-authors = ["toku-sa-n <tokusan441@gmail.com>"]
-edition = "2018"
-
-[lib]
-name = "ralib"
-test = false
-bench = false
-
-[features]
-default = []
+edition = "2021"
 
 [dependencies]
 conquer-once = { version = "0.3.2", default-features = false }
 linked_list_allocator = "0.9.0"
 os_units = "0.4.2"
-log = "0.4.14"
 page_box = { path = "../page_box" }
-syscalls = { path = "../syscalls" }
 x86_64 = { version = "0.14.4", default-features = false }
-accessor = "0.3.0"

--- a/libs/raheap/Cargo.toml
+++ b/libs/raheap/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2021"]
+
 [package]
 name = "raheap"
 version = "0.1.0"

--- a/libs/raheap/src/lib.rs
+++ b/libs/raheap/src/lib.rs
@@ -1,4 +1,7 @@
 #![no_std]
+// This is a workaround for
+// https://stackoverflow.com/questions/63933070/clippy-says-too-many-arguments-to-static-declaration.
+#![allow(clippy::too_many_arguments)]
 
 use conquer_once::spin::Lazy;
 use core::convert::TryInto;
@@ -28,6 +31,7 @@ impl Default for Heap {
     }
 }
 
+#[allow(clippy::missing_panics_doc)]
 pub fn init() {
     let a = ALLOCATOR.try_lock();
     let mut a = a.expect("Failed to acquire the lock of `HEAP`.");

--- a/libs/raheap/src/lib.rs
+++ b/libs/raheap/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 use conquer_once::spin::Lazy;
 use core::convert::TryInto;
 use linked_list_allocator::LockedHeap;
@@ -26,7 +28,7 @@ impl Default for Heap {
     }
 }
 
-pub(crate) fn init() {
+pub fn init() {
     let a = ALLOCATOR.try_lock();
     let mut a = a.expect("Failed to acquire the lock of `HEAP`.");
 

--- a/libs/ralib/Cargo.toml
+++ b/libs/ralib/Cargo.toml
@@ -10,11 +10,8 @@ test = false
 bench = false
 
 [dependencies]
-conquer-once = { version = "0.3.2", default-features = false }
-linked_list_allocator = "0.9.0"
 os_units = "0.4.2"
 log = "0.4.14"
-page_box = { path = "../page_box" }
 syscalls = { path = "../syscalls" }
 x86_64 = { version = "0.14.4", default-features = false }
 accessor = "0.3.0"

--- a/libs/ralib/Cargo.toml
+++ b/libs/ralib/Cargo.toml
@@ -9,9 +9,6 @@ name = "ralib"
 test = false
 bench = false
 
-[features]
-default = []
-
 [dependencies]
 conquer-once = { version = "0.3.2", default-features = false }
 linked_list_allocator = "0.9.0"

--- a/libs/ralib/src/lib.rs
+++ b/libs/ralib/src/lib.rs
@@ -11,13 +11,6 @@ pub mod mem;
 
 extern crate alloc;
 
-#[cfg(feature = "heap")]
-pub fn init() {
-    io::init();
-    mem::heap::init();
-}
-
-#[cfg(not(feature = "heap"))]
 pub fn init() {
     io::init();
 }

--- a/libs/ralib/src/mem/mod.rs
+++ b/libs/ralib/src/mem/mod.rs
@@ -1,6 +1,3 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 pub mod accessor;
-
-#[cfg(feature = "heap")]
-pub(crate) mod heap;

--- a/servers/do_nothing/Cargo.toml
+++ b/servers/do_nothing/Cargo.toml
@@ -10,5 +10,6 @@ test = false
 bench = false
 
 [dependencies]
+raheap = { path = "../../libs/raheap" }
 ralib = { path = "../../libs/ralib" }
 

--- a/servers/do_nothing/src/lib.rs
+++ b/servers/do_nothing/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![no_std]
 
+extern crate raheap as _;
 extern crate ralib as _;
 
 #[no_mangle]

--- a/servers/fs/Cargo.toml
+++ b/servers/fs/Cargo.toml
@@ -13,5 +13,6 @@ bench = false
 [dependencies]
 log = "0.4.14"
 message = { path = "../../libs/message" }
+raheap = { path = "../../libs/raheap" }
 ralib = { path = "../../libs/ralib" }
 syscalls = { path = "../../libs/syscalls" }

--- a/servers/fs/src/lib.rs
+++ b/servers/fs/src/lib.rs
@@ -11,6 +11,7 @@ use log::info;
 #[no_mangle]
 pub fn main() {
     ralib::init();
+    raheap::init();
 
     let mut c = ProcessCollection::default();
     init(&mut c);

--- a/servers/pm/Cargo.toml
+++ b/servers/pm/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2021"]
+
 [package]
 name = "pm"
 version = "0.1.0"

--- a/servers/pm/Cargo.toml
+++ b/servers/pm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pm"
 version = "0.1.0"
 authors = ["toku-sa-n <tokusan441@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "pm"

--- a/servers/pm/Cargo.toml
+++ b/servers/pm/Cargo.toml
@@ -13,5 +13,6 @@ bench = false
 [dependencies]
 message = { path = "../../libs/message" }
 num-traits = { version = "0.2.14", default-features = false }
+raheap = { path = "../../libs/raheap" }
 ralib = { path = "../../libs/ralib" }
 syscalls = { path = "../../libs/syscalls" }

--- a/servers/pm/src/lib.rs
+++ b/servers/pm/src/lib.rs
@@ -15,6 +15,7 @@ const INITIAL_PROCESS_SLOT_NUMBER: usize = 200;
 #[no_mangle]
 pub fn main() {
     ralib::init();
+    raheap::init();
 
     let mut processes = ProcessCollection::default();
     init(&mut processes);

--- a/servers/port_server/Cargo.toml
+++ b/servers/port_server/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4.14"
 message = { path = "../../libs/message" }
 num-derive = "0.3.3"
 num-traits = { version = "0.2.14", default-features = false }
+raheap = { path = "../../libs/raheap" }
 ralib = { path = "../../libs/ralib" }
 syscalls = { path = "../../libs/syscalls" }
 x86_64 = "0.14.4"

--- a/servers/port_server/src/lib.rs
+++ b/servers/port_server/src/lib.rs
@@ -18,6 +18,7 @@ pub fn main() {
 
 fn init() {
     ralib::init();
+    raheap::init();
 }
 
 fn main_loop() {

--- a/servers/xhci/Cargo.toml
+++ b/servers/xhci/Cargo.toml
@@ -23,6 +23,7 @@ num-derive = "0.3.3"
 num-traits = { version = "0.2.14", default-features = false }
 os_units = "0.4.2"
 page_box = { path = "../../libs/page_box" }
+raheap = { path = "../../libs/raheap" }
 ralib = { path = "../../libs/ralib" }
 spinning_top = { version = "0.2.4", features = ["nightly"] }
 syscalls = { path = "../../libs/syscalls" }

--- a/servers/xhci/src/lib.rs
+++ b/servers/xhci/src/lib.rs
@@ -31,6 +31,7 @@ mod xhc;
 #[no_mangle]
 pub fn main() {
     ralib::init();
+    raheap::init();
 
     init();
 


### PR DESCRIPTION
This commit splits the `ralib` crate and moves its heap implementation to the newly created `raheap` crate to prevent the duplicated global heap error caused by the workspace property.
