### PR TITLE
refactor: create the `predefined_mmap` crate

### DIFF
--- a/bootx64/Cargo.toml
+++ b/bootx64/Cargo.toml
@@ -22,3 +22,4 @@ common = { path = "../libs/common/" }
 x86_64 = "0.14.4"
 elf_rs = "0.1.3"
 os_units = "0.4.2"
+predefined_mmap = { path = "../libs/predefined_mmap" }

--- a/bootx64/src/fs/mod.rs
+++ b/bootx64/src/fs/mod.rs
@@ -2,7 +2,6 @@
 
 mod root_dir;
 
-use common::constant::KERNEL_ADDR;
 use core::{
     convert::{TryFrom, TryInto},
     slice,
@@ -11,6 +10,7 @@ use elf_rs::Elf;
 use file::{FileInfo, FileType};
 use log::info;
 use os_units::Bytes;
+use predefined_mmap::KERNEL_ADDR;
 use uefi::{
     proto::media::{
         file,

--- a/bootx64/src/jump.rs
+++ b/bootx64/src/jump.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use common::{constant::INIT_RSP, kernelboot};
+use common::kernelboot;
+use predefined_mmap::INIT_RSP;
 
 macro_rules! change_rsp{
     ($val:expr)=>{

--- a/bootx64/src/mem/paging.rs
+++ b/bootx64/src/mem/paging.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use common::{constant::RECUR_PML4_ADDR, kernelboot, mem::reserved};
+use common::{kernelboot, mem::reserved};
 use core::convert::TryFrom;
+use predefined_mmap::RECUR_PML4_ADDR;
 use uefi::table::{boot, boot::MemoryType};
 use x86_64::{
     addr::PhysAddr,

--- a/bootx64/src/mem/stack.rs
+++ b/bootx64/src/mem/stack.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use common::constant::NUM_OF_PAGES_STACK;
+use predefined_mmap::NUM_OF_PAGES_STACK;
 use uefi::{
     table::{
         boot,

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -43,6 +43,7 @@ cstr_core = "0.2.4"
 xmas-elf = "0.8.0"
 uart_16550 = "0.2.15"
 spinning_top = { version = "0.2.4", features = ["nightly"] }
+predefined_mmap = { path = "../libs/predefined_mmap" }
 
 [build-dependencies]
 cc = "1.0.69"

--- a/kernel/src/mem/allocator/virt.rs
+++ b/kernel/src/mem/allocator/virt.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use crate::mem::paging::pml4::PML4;
-use common::constant::BYTES_AVAILABLE_RAM;
 use core::convert::TryFrom;
 use os_units::NumOfPages;
+use predefined_mmap::BYTES_AVAILABLE_RAM;
 use x86_64::{
     structures::paging::{PageSize, Size4KiB, Translate},
     VirtAddr,

--- a/kernel/src/mem/paging/mod.rs
+++ b/kernel/src/mem/paging/mod.rs
@@ -2,7 +2,7 @@
 
 pub(crate) mod pml4;
 
-use common::constant::RECUR_PML4_ADDR;
+use predefined_mmap::RECUR_PML4_ADDR;
 use x86_64::structures::paging::PageTable;
 
 pub(crate) fn mark_pages_as_unused() {

--- a/kernel/src/mem/paging/pml4.rs
+++ b/kernel/src/mem/paging/pml4.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use common::constant::RECUR_PML4_ADDR;
 use conquer_once::spin::Lazy;
+use predefined_mmap::RECUR_PML4_ADDR;
 use spinning_top::Spinlock;
 use x86_64::structures::paging::RecursivePageTable;
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -10,9 +10,9 @@ pub(crate) mod switch;
 
 use crate::{mem::allocator::kpbox::KpBox, tss::TSS};
 use alloc::collections::VecDeque;
-use common::constant::INTERRUPT_STACK;
 use core::convert::TryInto;
 pub(crate) use exit::exit_process;
+use predefined_mmap::INTERRUPT_STACK;
 pub(crate) use slot_id::SlotId;
 use stack_frame::StackFrame;
 pub(crate) use switch::switch;

--- a/kernel/src/tss.rs
+++ b/kernel/src/tss.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use common::constant::INTERRUPT_STACK;
 use conquer_once::spin::Lazy;
+use predefined_mmap::INTERRUPT_STACK;
 use spinning_top::Spinlock;
 use x86_64::structures::tss::TaskStateSegment;
 

--- a/libs/common/Cargo.toml
+++ b/libs/common/Cargo.toml
@@ -11,3 +11,4 @@ uefi = "0.11.0"
 os_units = "0.4.2"
 vek = { version = "0.15.1", default-features = false, features = ["libm"] }
 conquer-once = { version = "0.3.2", default-features = false }
+predefined_mmap = { path = "../predefined_mmap" }

--- a/libs/common/src/kernelboot.rs
+++ b/libs/common/src/kernelboot.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::{constant::INIT_RSP, mem, vram};
+use crate::{mem, vram};
 use core::ptr;
+use predefined_mmap::INIT_RSP;
 use uefi::table::boot;
 use x86_64::{PhysAddr, VirtAddr};
 

--- a/libs/common/src/lib.rs
+++ b/libs/common/src/lib.rs
@@ -4,7 +4,6 @@
 #![deny(clippy::pedantic)]
 #![deny(clippy::all)]
 
-pub mod constant;
 pub mod debug;
 pub mod kernelboot;
 pub mod mem;

--- a/libs/common/src/mem/reserved.rs
+++ b/libs/common/src/mem/reserved.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::{
-    constant::{KERNEL_ADDR, NUM_OF_PAGES_STACK, STACK_LOWER, VRAM_ADDR},
-    vram,
-};
+use crate::vram;
 use os_units::Bytes;
+use predefined_mmap::{KERNEL_ADDR, NUM_OF_PAGES_STACK, STACK_LOWER, VRAM_ADDR};
 use x86_64::{PhysAddr, VirtAddr};
 
 #[derive(Copy, Clone, Debug)]

--- a/libs/predefined_mmap/Cargo.toml
+++ b/libs/predefined_mmap/Cargo.toml
@@ -1,9 +1,9 @@
+cargo-features = ["edition2021"]
+
 [package]
 name = "predefined_mmap"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 conquer-once = { version = "0.3.2", default-features = false }

--- a/libs/predefined_mmap/Cargo.toml
+++ b/libs/predefined_mmap/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "predefined_mmap"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+conquer-once = { version = "0.3.2", default-features = false }
+os_units = "0.4.2"
+x86_64 = { version = "0.14.6", default-features = false }

--- a/libs/predefined_mmap/src/lib.rs
+++ b/libs/predefined_mmap/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+#![no_std]
 
 use conquer_once::spin::Lazy;
 use os_units::{Bytes, NumOfPages};

--- a/libs/terminal/Cargo.toml
+++ b/libs/terminal/Cargo.toml
@@ -10,6 +10,7 @@ common = { path = "../common" }
 conquer-once = { version = "0.3.2", default-features = false }
 font8x8 = { version = "0.3.1", features = ["unicode"], default-features = false }
 log = "0.4.14"
+predefined_mmap = { path = "../predefined_mmap" }
 rgb = "0.8.27"
 spinning_top = { version = "0.2.4", features = ["nightly"] }
 vek = { version = "0.15.1", default-features = false, features = ["libm"] }

--- a/libs/terminal/src/vram.rs
+++ b/libs/terminal/src/vram.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::font::HEIGHT;
-use common::{constant::VRAM_ADDR, kernelboot};
+use common::kernelboot;
 use conquer_once::spin::OnceCell;
 use core::{
     convert::{TryFrom, TryInto},
@@ -9,6 +9,7 @@ use core::{
     slice,
 };
 use log::info;
+use predefined_mmap::VRAM_ADDR;
 use rgb::RGB8;
 use spinning_top::{Spinlock, SpinlockGuard};
 use vek::Vec2;


### PR DESCRIPTION
This commit moves the `constant` module in the `common` crate to the newly created `predefined_mmap` crate. The name "common" originates from "things which both the kernel and the bootloader codes need". However, the term is ambiguous, and I threw lots of codes into the crate. So this commit splits the `common` crate.
