### PR TITLE
refactor: create the `boot_info` crate

### DIFF
--- a/bootx64/Cargo.toml
+++ b/bootx64/Cargo.toml
@@ -23,3 +23,4 @@ x86_64 = "0.14.4"
 elf_rs = "0.1.3"
 os_units = "0.4.2"
 predefined_mmap = { path = "../libs/predefined_mmap" }
+boot_info = { path = "../libs/boot_info" }

--- a/bootx64/src/exit.rs
+++ b/bootx64/src/exit.rs
@@ -11,7 +11,7 @@ use uefi::{
 ///
 /// This function panics if it fails to allocate a memory for the memory map.
 #[must_use]
-pub fn boot_services(image: Handle, system_table: SystemTable<Boot>) -> common::mem::Map {
+pub fn boot_services(image: Handle, system_table: SystemTable<Boot>) -> boot_info::mem::Map {
     info!("Goodbye, boot services...");
     let memory_map_buf = system_table
         .boot_services()
@@ -30,7 +30,7 @@ pub fn boot_services(image: Handle, system_table: SystemTable<Boot>) -> common::
 
     let num_descriptors = descriptors_iter.len();
     let memory_map_buf = write_descriptors_on_buf(memory_map_buf, &mut descriptors_iter);
-    common::mem::Map::new(memory_map_buf, num_descriptors)
+    boot_info::mem::Map::new(memory_map_buf, num_descriptors)
 }
 
 fn allocate_buf_for_exiting(bs: &boot::BootServices) -> &'static mut [u8] {

--- a/bootx64/src/gop.rs
+++ b/bootx64/src/gop.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use common::vram;
+use boot_info::vram;
 use core::mem::MaybeUninit;
 use log::info;
 use uefi::{

--- a/bootx64/src/jump.rs
+++ b/bootx64/src/jump.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use common::kernelboot;
 use predefined_mmap::INIT_RSP;
 
 macro_rules! change_rsp{
@@ -11,17 +10,17 @@ macro_rules! change_rsp{
     }
 }
 
-pub fn to_kernel(boot_info: kernelboot::Info) -> ! {
+pub fn to_kernel(boot_info: boot_info::Info) -> ! {
     disable_interruption();
 
     boot_info.set();
 
     change_rsp!(INIT_RSP.as_u64());
 
-    let boot_info = kernelboot::Info::get();
+    let boot_info = boot_info::Info::get();
 
     let kernel = unsafe {
-        core::mem::transmute::<u64, fn(kernelboot::Info) -> !>(boot_info.entry_addr().as_u64())
+        core::mem::transmute::<u64, fn(boot_info::Info) -> !>(boot_info.entry_addr().as_u64())
     };
 
     kernel(boot_info)

--- a/bootx64/src/main.rs
+++ b/bootx64/src/main.rs
@@ -15,7 +15,7 @@ use bootx64::{
     mem::{paging, stack},
     rsdp,
 };
-use common::{kernelboot, mem::reserved};
+use common::mem::reserved;
 use uefi::prelude::{Boot, Handle, SystemTable};
 
 #[start]
@@ -38,7 +38,7 @@ pub fn efi_main(image: Handle, system_table: SystemTable<Boot>) -> ! {
     );
     let mem_map = bootx64::exit::boot_services(image, system_table);
 
-    let mut boot_info = kernelboot::Info::new(entry_addr, vram_info, mem_map, rsdp);
+    let mut boot_info = boot_info::Info::new(entry_addr, vram_info, mem_map, rsdp);
 
     paging::init(&mut boot_info, &reserved_regions);
     jump::to_kernel(boot_info);

--- a/bootx64/src/mem/paging.rs
+++ b/bootx64/src/mem/paging.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use common::{kernelboot, mem::reserved};
+use common::mem::reserved;
 use core::convert::TryFrom;
 use predefined_mmap::RECUR_PML4_ADDR;
 use uefi::table::{boot, boot::MemoryType};
@@ -39,7 +39,7 @@ unsafe impl FrameAllocator<Size4KiB> for AllocatorWithEfiMemoryMap<'_> {
     }
 }
 
-pub fn init(boot_info: &mut kernelboot::Info, reserved: &reserved::Map) {
+pub fn init(boot_info: &mut boot_info::Info, reserved: &reserved::Map) {
     remove_table_protection();
 
     enable_recursive_mapping();

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -20,7 +20,6 @@ test = false
 bench = false
 
 [dependencies]
-common = { path = "../libs/common" }
 conquer-once = { version = "0.3.2", default-features = false }
 x86_64 = { version = "0.14.4", default-features = false }
 linked_list_allocator = "0.9.0"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -44,6 +44,7 @@ xmas-elf = "0.8.0"
 uart_16550 = "0.2.15"
 spinning_top = { version = "0.2.4", features = ["nightly"] }
 predefined_mmap = { path = "../libs/predefined_mmap" }
+boot_info = { path = "../libs/boot_info" }
 
 [build-dependencies]
 cc = "1.0.69"

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -19,7 +19,6 @@ mod sysproc;
 mod tests;
 mod tss;
 
-use common::kernelboot;
 use interrupt::{apic, idt, timer};
 use log::info;
 use process::Privilege;
@@ -27,12 +26,12 @@ use terminal::vram;
 use x86_64::software_interrupt;
 
 #[no_mangle]
-pub extern "win64" fn os_main(mut boot_info: kernelboot::Info) -> ! {
+pub extern "win64" fn os_main(mut boot_info: boot_info::Info) -> ! {
     init(&mut boot_info);
     cause_timer_interrupt();
 }
 
-fn init(boot_info: &mut kernelboot::Info) {
+fn init(boot_info: &mut boot_info::Info) {
     vram::init(boot_info);
 
     terminal::log::init().unwrap();

--- a/libs/boot_info/Cargo.toml
+++ b/libs/boot_info/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "boot_info"
 version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2018"
 
 [dependencies]
 os_units = "0.4.2"

--- a/libs/boot_info/Cargo.toml
+++ b/libs/boot_info/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "boot_info"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+os_units = "0.4.2"
+predefined_mmap = { path = "../predefined_mmap" }
+uefi = "0.11.0"
+vek = { version = "0.15.1", features = ["libm"], default-features = false }
+x86_64 = { version = "0.14.6", default-features = false }

--- a/libs/boot_info/src/lib.rs
+++ b/libs/boot_info/src/lib.rs
@@ -1,6 +1,8 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+#![no_std]
 
-use crate::{mem, vram};
+pub mod mem;
+pub mod vram;
+
 use core::ptr;
 use predefined_mmap::INIT_RSP;
 use uefi::table::boot;

--- a/libs/boot_info/src/mem.rs
+++ b/libs/boot_info/src/mem.rs
@@ -1,0 +1,24 @@
+use core::{ptr::NonNull, slice};
+use uefi::table::boot;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct Map {
+    ptr: NonNull<boot::MemoryDescriptor>,
+    num_descriptors: usize,
+}
+
+impl Map {
+    #[must_use]
+    pub fn new(ptr: NonNull<boot::MemoryDescriptor>, num_descriptors: usize) -> Self {
+        Self {
+            ptr,
+            num_descriptors,
+        }
+    }
+
+    #[must_use]
+    pub fn as_mut_slice(&mut self) -> &mut [boot::MemoryDescriptor] {
+        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.num_descriptors) }
+    }
+}

--- a/libs/boot_info/src/vram.rs
+++ b/libs/boot_info/src/vram.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-
 use core::convert::TryFrom;
 use os_units::Bytes;
 use uefi::proto::console::gop;

--- a/libs/common/Cargo.toml
+++ b/libs/common/Cargo.toml
@@ -12,3 +12,4 @@ os_units = "0.4.2"
 vek = { version = "0.15.1", default-features = false, features = ["libm"] }
 conquer-once = { version = "0.3.2", default-features = false }
 predefined_mmap = { path = "../predefined_mmap" }
+boot_info = { path = "../boot_info" }

--- a/libs/common/src/lib.rs
+++ b/libs/common/src/lib.rs
@@ -5,6 +5,4 @@
 #![deny(clippy::all)]
 
 pub mod debug;
-pub mod kernelboot;
 pub mod mem;
-pub mod vram;

--- a/libs/common/src/mem/mod.rs
+++ b/libs/common/src/mem/mod.rs
@@ -1,28 +1,3 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 pub mod reserved;
-
-use core::{ptr::NonNull, slice};
-use uefi::table::boot;
-
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub struct Map {
-    ptr: NonNull<boot::MemoryDescriptor>,
-    num_descriptors: usize,
-}
-
-impl Map {
-    #[must_use]
-    pub fn new(ptr: NonNull<boot::MemoryDescriptor>, num_descriptors: usize) -> Self {
-        Self {
-            ptr,
-            num_descriptors,
-        }
-    }
-
-    #[must_use]
-    pub fn as_mut_slice(&mut self) -> &mut [boot::MemoryDescriptor] {
-        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.num_descriptors) }
-    }
-}

--- a/libs/common/src/mem/reserved.rs
+++ b/libs/common/src/mem/reserved.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::vram;
+use boot_info::vram;
 use os_units::Bytes;
 use predefined_mmap::{KERNEL_ADDR, NUM_OF_PAGES_STACK, STACK_LOWER, VRAM_ADDR};
 use x86_64::{PhysAddr, VirtAddr};

--- a/libs/terminal/Cargo.toml
+++ b/libs/terminal/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies]
 bit_field = "0.10.1"
 boot_info = { path = "../boot_info" }
-common = { path = "../common" }
 conquer-once = { version = "0.3.2", default-features = false }
 font8x8 = { version = "0.3.1", features = ["unicode"], default-features = false }
 log = "0.4.14"

--- a/libs/terminal/Cargo.toml
+++ b/libs/terminal/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 bit_field = "0.10.1"
+boot_info = { path = "../boot_info" }
 common = { path = "../common" }
 conquer-once = { version = "0.3.2", default-features = false }
 font8x8 = { version = "0.3.1", features = ["unicode"], default-features = false }

--- a/libs/terminal/src/vram.rs
+++ b/libs/terminal/src/vram.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::font::HEIGHT;
-use common::kernelboot;
 use conquer_once::spin::OnceCell;
 use core::{
     convert::{TryFrom, TryInto},
@@ -17,7 +16,7 @@ use vek::Vec2;
 static VRAM: Spinlock<Vram> = Spinlock::new(Vram);
 static INFO: OnceCell<Info> = OnceCell::uninit();
 
-pub fn init(boot_info: &kernelboot::Info) {
+pub fn init(boot_info: &boot_info::Info) {
     init_info(boot_info);
     clear_screen();
 }
@@ -50,7 +49,7 @@ fn lock() -> SpinlockGuard<'static, Vram> {
         .expect("Failed to acquire the lock of `VRAM`")
 }
 
-fn init_info(boot_info: &kernelboot::Info) {
+fn init_info(boot_info: &boot_info::Info) {
     INFO.try_init_once(|| Info::new_from_boot_info(boot_info))
         .expect("`INFO` is initialized more than once.");
 }
@@ -76,7 +75,7 @@ impl Info {
         self.bits_per_pixel
     }
 
-    fn new_from_boot_info(boot_info: &kernelboot::Info) -> Self {
+    fn new_from_boot_info(boot_info: &boot_info::Info) -> Self {
         let vram = boot_info.vram();
 
         Self::new(vram.bpp(), vram.resolution())


### PR DESCRIPTION
This commit moves the `kernelboot` module to the newly created `boot_info` crate. There are two purposes to do this. Firstly, to remove the `common` crate, which is now a garbage can where codes have nowhere to go. Secondly, to solve a problem caused by the workspace's property. Currently, the `boot_info` crate depends on the `uefi` crate, so does the `bootx64` crate. Also, the `bootx64` crate enables its allocation feature.
Furthermore, the kernel depends on the crate so that the compiler will build the kernel with the duplicated global allocator. See https://stackoverflow.com/questions/68955652/how-to-avoid-global-allocator-conflicts/68977928#68977928 for the detail. On another PR, I will remove the `uefi` dependency from the crate.
