### PR TITLE
chore: use edition 2018

### DIFF
--- a/libs/predefined_mmap/Cargo.toml
+++ b/libs/predefined_mmap/Cargo.toml
@@ -1,9 +1,7 @@
-cargo-features = ["edition2021"]
-
 [package]
 name = "predefined_mmap"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 conquer-once = { version = "0.3.2", default-features = false }

--- a/libs/raheap/Cargo.toml
+++ b/libs/raheap/Cargo.toml
@@ -1,9 +1,7 @@
-cargo-features = ["edition2021"]
-
 [package]
 name = "raheap"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 [lib]
 name = "raheap"

--- a/servers/pm/Cargo.toml
+++ b/servers/pm/Cargo.toml
@@ -1,10 +1,8 @@
-cargo-features = ["edition2021"]
-
 [package]
 name = "pm"
 version = "0.1.0"
 authors = ["toku-sa-n <tokusan441@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 [lib]
 name = "pm"


### PR DESCRIPTION
Dependabot does not work well with edition 2021.
