### PR TITLE
chore: cause a compile error deliberately

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -25,8 +25,6 @@ use process::Privilege;
 use terminal::vram;
 use x86_64::software_interrupt;
 
-compile_error!("Clippy test.");
-
 #[no_mangle]
 pub extern "win64" fn os_main(mut boot_info: boot_info::Info) -> ! {
     init(&mut boot_info);

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -25,6 +25,8 @@ use process::Privilege;
 use terminal::vram;
 use x86_64::software_interrupt;
 
+compile_error!("Clippy test.");
+
 #[no_mangle]
 pub extern "win64" fn os_main(mut boot_info: boot_info::Info) -> ! {
     init(&mut boot_info);

--- a/kernel/src/mem/accessor.rs
+++ b/kernel/src/mem/accessor.rs
@@ -22,7 +22,7 @@ impl accessor::Mapper for Mapper {
         let bytes = Bytes::new(bytes);
 
         let v = super::map_pages(phys_start, bytes);
-        let v: usize = v.as_u64().try_into().unwrap();
+        let v: usize = v.as_u64() as _;
 
         NonZeroUsize::new(v).expect("Failed to map pages.")
     }


### PR DESCRIPTION
To check whether the clippy CI works or not.
