### PR TITLE
chore: separate the initrd binary from the kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ test:
 	make clean
 	make $(IMG_FILE) TEST_FLAG=--features=qemu_test
 
-$(IMG_FILE):$(KERNEL_FILE) $(EFI_FILE)
+$(IMG_FILE):$(KERNEL_FILE) $(EFI_FILE) $(INITRD)
 	dd if=/dev/zero of=$@ bs=1k count=28800
 	mformat -i $@ -h 200 -t 500 -s 144::
 	# Cannot replace these mmd and mcopy with `make copy_to_usb` because `mount` needs `sudo`
@@ -121,12 +121,13 @@ $(IMG_FILE):$(KERNEL_FILE) $(EFI_FILE)
 	mmd -i $@ ::/efi
 	mmd -i $@ ::/efi/boot
 	mcopy -i $@ $(KERNEL_FILE) ::
+	mcopy -i $@ $(INITRD) ::
 	mcopy -i $@ $(EFI_FILE) ::/efi/boot
 
 $(KERNEL_FILE):$(KERNEL_LIB) $(KERNEL_LD)|$(BUILD_DIR)
 	$(LD) $(LDFLAGS) -o $@ $(KERNEL_LIB) -T $(KERNEL_LD)
 
-$(KERNEL_LIB):$(KERNEL_LIB_SRC) $(INITRD) $(KERNEL_LIB_DEPENDENCIES_SRC)|$(BUILD_DIR)
+$(KERNEL_LIB):$(KERNEL_LIB_SRC) $(KERNEL_LIB_DEPENDENCIES_SRC)|$(BUILD_DIR)
 	# FIXME: Currently `cargo` tries to read `$(pwd)/.cargo/config.toml`, not
 	# `$(dirname argument_of_--manifest-path)/.cargo/config.toml`.
 	# See: https://github.com/rust-lang/cargo/issues/2930

--- a/bootx64/src/main.rs
+++ b/bootx64/src/main.rs
@@ -28,6 +28,7 @@ pub fn efi_main(image: Handle, mut system_table: SystemTable<Boot>) -> ! {
     let vram_info = gop::init(system_table.boot_services());
 
     let (phys_kernel_addr, bytes_kernel) = fs::deploy(system_table.boot_services(), "kernel.bin");
+    let (phys_initrd_addr, bytes_initrd) = fs::deploy(system_table.boot_services(), "initrd.cpio");
     let (entry_addr, actual_mem_size) =
         fs::fetch_entry_address_and_memory_size(phys_kernel_addr, bytes_kernel);
 
@@ -37,6 +38,8 @@ pub fn efi_main(image: Handle, mut system_table: SystemTable<Boot>) -> ! {
         &reserved::PhysRange::new(phys_kernel_addr, actual_mem_size),
         stack_addr,
         &vram_info,
+        phys_initrd_addr,
+        bytes_initrd,
     );
     let mem_map = bootx64::exit::boot_services(image, system_table);
 

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -1,26 +1,7 @@
-use std::process::Command;
-
 fn main() {
-    println!("cargo:rerun-if-changed=../build/initrd.cpio");
-    println!("cargo:rerun-if-changed=src/initrd.s");
-    touch_initrd().expect("Failed to `touch` the initrd cpio file.");
-    cc::Build::new().file("src/initrd.s").compile("initrd");
     cc::Build::new()
         .file("src/interrupt/handler.s")
         .compile("handler");
     cc::Build::new().file("src/asm.s").compile("asm");
     cc::Build::new().file("src/qemu.s").compile("qemu");
-}
-
-fn touch_initrd() -> Result<(), std::io::Error> {
-    Command::new("mkdir")
-        .arg("-p")
-        .arg("../build/")
-        .spawn()?
-        .wait()?;
-    Command::new("touch")
-        .arg("../build/initrd.cpio")
-        .spawn()?
-        .wait()?;
-    Ok(())
 }

--- a/kernel/src/fs.rs
+++ b/kernel/src/fs.rs
@@ -31,10 +31,6 @@ fn iter() -> impl Iterator<Item = CpioArchievedFile> {
     Iter::default()
 }
 
-fn initrd_addr() -> VirtAddr {
-    INITRD_ADDR
-}
-
 pub(super) struct CpioArchievedFile {
     ptr: VirtAddr,
 }
@@ -98,7 +94,7 @@ impl Iterator for Iter {
 }
 impl Default for Iter {
     fn default() -> Self {
-        Self { ptr: initrd_addr() }
+        Self { ptr: INITRD_ADDR }
     }
 }
 

--- a/kernel/src/fs.rs
+++ b/kernel/src/fs.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use predefined_mmap::INITRD_ADDR;
+
 use {
     core::{
         convert::{TryFrom, TryInto},
@@ -30,12 +32,7 @@ fn iter() -> impl Iterator<Item = CpioArchievedFile> {
 }
 
 fn initrd_addr() -> VirtAddr {
-    extern "C" {
-        static initrd: usize;
-    }
-
-    let a: *const usize = unsafe { &initrd };
-    VirtAddr::new(a as _)
+    INITRD_ADDR
 }
 
 pub(super) struct CpioArchievedFile {

--- a/kernel/src/initrd.s
+++ b/kernel/src/initrd.s
@@ -1,3 +1,0 @@
-    .global initrd
-initrd:
-    .incbin "../build/initrd.cpio"

--- a/libs/common/src/mem/reserved.rs
+++ b/libs/common/src/mem/reserved.rs
@@ -1,3 +1,5 @@
+use predefined_mmap::INITRD_ADDR;
+
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use {
@@ -22,16 +24,23 @@ impl PhysRange {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-pub struct Map([Range; 3]);
+pub struct Map([Range; 4]);
 impl Map {
     #[must_use]
     #[allow(clippy::too_many_arguments)]
-    pub fn new(kernel: &PhysRange, phys_addr_stack: PhysAddr, vram: &vram::Info) -> Self {
+    pub fn new(
+        kernel: &PhysRange,
+        phys_addr_stack: PhysAddr,
+        vram: &vram::Info,
+        phys_addr_initrd: PhysAddr,
+        bytes_initrd: Bytes,
+    ) -> Self {
         Self {
             0: [
                 Range::kernel(kernel),
                 Range::stack(phys_addr_stack),
                 Range::vram(vram),
+                Range::initrd(phys_addr_initrd, bytes_initrd),
             ],
         }
     }
@@ -75,6 +84,15 @@ impl Range {
             virt: *STACK_LOWER,
             phys,
             bytes: NUM_OF_PAGES_STACK.as_bytes(),
+        }
+    }
+
+    #[must_use]
+    fn initrd(phys: PhysAddr, bytes: Bytes) -> Self {
+        Self {
+            virt: INITRD_ADDR,
+            phys,
+            bytes,
         }
     }
 


### PR DESCRIPTION
For #1034.
