### PR TITLE
test: remove the exit test

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -82,7 +82,6 @@ fn add_processes() {
 
     if cfg!(feature = "qemu_test") {
         process::from_function(tests::main, "tests");
-        process::from_function(tests::process::exit_test, "exittest");
     }
 }
 

--- a/kernel/src/tests/process/mod.rs
+++ b/kernel/src/tests/process/mod.rs
@@ -13,7 +13,3 @@ pub(crate) fn count_switch() {
         SWITCH_TEST_SUCCESS.fetch_or(true, Ordering::Relaxed);
     }
 }
-
-pub(crate) fn exit_test() {
-    syscalls::exit();
-}


### PR DESCRIPTION
We will remove the exit system call. It turned out that it is difficult
to implement it correctly.
