### PR TITLE
ci: do not run on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@
 
 name: Test
 
-on: [push, pull_request]
+on: [pull_request]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
I think this solves the problem that Clippy always fails on the first
run for PRs from the others.
